### PR TITLE
Transform controls

### DIFF
--- a/packages/jupytercad-extension/src/panelview/objecttree.tsx
+++ b/packages/jupytercad-extension/src/panelview/objecttree.tsx
@@ -276,8 +276,6 @@ class ObjectTreeReact extends React.Component<IProps, IStates> {
               return;
             }
 
-            console.log('toggle selected', id);
-
             if (id && id.length > 0) {
               const names: string[] = [];
               for (const subid of id) {


### PR DESCRIPTION
Applying rotation/translation from the UI is currently very precise but cumbersome. I want a way to apply transformations in a more user-friendly way.

> **Warning**
> Early draft, I should finish my multi-selection PR first.

![Screenshot from 2023-05-25 10-53-34](https://github.com/QuantStack/jupytercad/assets/21197331/f017a0e5-04d3-4dd6-b2d3-0521ee09dd42)

TODO:
- [x] Our 3D meshes all have position [0, 0, 0] instead of taking the centroid of geometries, we should take the centroid of geometries in order for the transform control to work properly
- [ ] Transforming from the UI should update the object in the shared model
