### PR TITLE
Fix object selection

### DIFF
--- a/packages/base/src/panelview/objectproperties.tsx
+++ b/packages/base/src/panelview/objectproperties.tsx
@@ -211,6 +211,7 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
           this.setState(old => ({
             ...old,
             schema: undefined,
+            selectedObject: '',
             selectedObjectData: undefined
           }));
           return;

--- a/python/jupytercad_app/jupytercad_app/utils.py
+++ b/python/jupytercad_app/jupytercad_app/utils.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     __version__ = "dev"
 
+from typing import Dict
 from jupyter_server.utils import url_path_join
 from jupyterlab_server.config import get_page_config as gpc
 from jupyter_server.config_manager import recursive_update
@@ -33,8 +34,10 @@ def get_page_config(base_url, app_name):
         "@jupytercad/jupytercad-core",
         "@jupyter/collaboration-extension",
     ]
-    federated_extensions = page_config["federated_extensions"]
+    federated_extensions: Dict[str, Dict] = page_config["federated_extensions"]
     page_config["federated_extensions"] = [
-        x for x in federated_extensions if x["name"] in required_extensions
+        x
+        for x in federated_extensions
+        if x["name"] in required_extensions or x["name"].startswith("@jupytercad/")
     ]
     return page_config

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "scripts": {
     "start": "jupyter lab --config jupyter_server_test_config.py",
-    "test": "npx playwright test",
+    "test": "npx playwright test --workers 1",
     "test:update": "npx playwright test --update-snapshots",
-    "test:debug": "PWDEBUG=1 npx playwright test"
+    "test:debug": "PWDEBUG=1 npx playwright test --workers 1"
   },
   "devDependencies": {
     "@jupyterlab/galata": "^5.0.8",

--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -12,6 +12,11 @@ module.exports = {
     reuseExistingServer: false
   },
   retries: 1,
+  use: {
+    ...baseConfig.use,
+    trace: 'off',
+
+  },
   expect: {
     toMatchSnapshot: {
       maxDiffPixelRatio: 0.02,


### PR DESCRIPTION
- Closes #174 
- Additional change: JupyterCad app will activate all extension prefixed with `@jupytercad/`

https://github.com/jupytercad/jupytercad/assets/4451292/834221fc-d23d-4c98-b262-7b06361dba7f

