### PR TITLE
Support loading STL binary format

### DIFF
--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -548,13 +548,10 @@ export class MainView extends React.Component<IProps, IStates> {
 
     if (selection) {
       // TODO Support selecting edges?
-      let selectionName = '';
-      if (selection.mesh.name.startsWith('edge')) {
+      let selectionName = selection.mesh.name;
+      if (selectionName.startsWith('edge') || selectionName === '') {
         selectionName = (selection.mesh.parent as BasicMesh).name;
-      } else {
-        selectionName = selection.mesh.name;
       }
-
       if (e.ctrlKey) {
         if (selectedMeshesNames.has(selectionName)) {
           selectedMeshesNames.delete(selectionName);

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -92,8 +92,8 @@ export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   setOption(key: keyof IJCadOptions, value: IDict): void;
   setOptions(options: IJCadOptions): void;
 
-  getOutput(key: string): string | undefined;
-  setOutput(key: string, value: string): void;
+  getOutput(key: string): IPostResult | undefined;
+  setOutput(key: string, value: IPostResult): void;
   removeOutput(key: string): void;
 
   getMetadata(key: string): string | undefined;
@@ -247,11 +247,16 @@ export interface IWorkerInitialized extends IMainMessageBase {
   payload: boolean;
 }
 
+export interface IPostResult {
+  format: 'STL'; // Supported format, for now only STL is supported.
+  value: any;
+  binary: boolean;
+}
 export interface IDisplayPost extends IMainMessageBase {
   action: MainAction.DISPLAY_POST;
   payload: {
     jcObject: IJCadObject;
-    postResult: any;
+    postResult: IPostResult;
   }[];
 }
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -22,6 +22,7 @@ import {
   IJupyterCadDoc,
   IJupyterCadDocChange,
   IJupyterCadModel,
+  IPostResult,
   IUserData,
   Pointer
 } from './interfaces';
@@ -280,7 +281,7 @@ export class JupyterCadDoc
     this._options = this.ydoc.getMap<Y.Map<any>>('options');
     this._objects = this.ydoc.getArray<Y.Map<any>>('objects');
     this._metadata = this.ydoc.getMap<string>('metadata');
-    this._outputs = this.ydoc.getMap<string>('outputs');
+    this._outputs = this.ydoc.getMap<IPostResult>('outputs');
     this.undoManager.addToScope(this._objects);
 
     this._objects.observeDeep(this._objectsObserver);
@@ -419,11 +420,11 @@ export class JupyterCadDoc
     }
   }
 
-  getOutput(key: string): string | undefined {
+  getOutput(key: string): IPostResult | undefined {
     return this._outputs.get(key);
   }
 
-  setOutput(key: string, value: string): void {
+  setOutput(key: string, value: IPostResult): void {
     this.transact(() => void this._outputs.set(key, value));
   }
 
@@ -496,7 +497,7 @@ export class JupyterCadDoc
   private _objects: Y.Array<Y.Map<any>>;
   private _options: Y.Map<any>;
   private _metadata: Y.Map<string>;
-  private _outputs: Y.Map<string>;
+  private _outputs: Y.Map<IPostResult>;
   private _metadataChanged = new Signal<IJupyterCadDoc, MapChange>(this);
   private _optionsChanged = new Signal<IJupyterCadDoc, MapChange>(this);
   private _objectsChanged = new Signal<IJupyterCadDoc, IJcadObjectDocChange>(


### PR DESCRIPTION
- New post-processing result interface:
```ts
export interface IPostResult {
  format: 'STL'; // Supported format, for now only STL is supported.
  value: any;
  binary: boolean;
}
```
- The 3D viewer can load STL binary format. 