### PR TITLE
Pin JupyterLab in publish release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,7 @@ jobs:
           environment-name: cad
           create-args: >-
             python=3.9
-            jupyterlab=4
+            jupyterlab=4.0.12
             yarn=3
 
       - name: Populate Release


### PR DESCRIPTION
JupyterLab prevents us from building and releasing. Some issues will be fixed by https://github.com/jupytercad/jupytercad/pull/251