### PR TITLE
Implement clipping

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -25,7 +25,8 @@ import {
   requestAPI,
   sphereIcon,
   torusIcon,
-  unionIcon
+  unionIcon,
+  clippingIcon
 } from './tools';
 import { JupyterCadPanel, JupyterCadWidget } from './widget';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
@@ -715,9 +716,9 @@ export function addCommands(
   });
 
   commands.addCommand(CommandIDs.updateClipView, {
-    label: trans.__('Clip View'),
+    label: trans.__('Clipping'),
     isEnabled: () => Boolean(tracker.currentWidget),
-    iconClass: 'fa fa-paperclip',
+    icon: clippingIcon,
     execute: async () => {
       const current = tracker.currentWidget;
 

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -418,19 +418,25 @@ const CLIP_VIEW_FORM = {
       Enabled: {
         type: 'boolean',
         description: 'Whether the clip view is enabled or not'
-      }
+      },
+      ShowClipPlane: {
+        type: 'boolean',
+        description: 'Whether the clip plane should be rendered or not'
+      },
     }
   },
   default: (panel: JupyterCadPanel) => {
     return {
-      Enabled: panel.clipView?.enabled ?? false
+      Enabled: panel.clipView?.enabled ?? false,
+      ShowClipPlane: panel.clipView?.showClipPlane ?? true
     };
   },
   syncData: (panel: JupyterCadPanel) => {
     return (props: IDict) => {
-      const { Enabled } = props;
+      const { Enabled, ShowClipPlane } = props;
       panel.clipView = {
-        enabled: Enabled
+        enabled: Enabled,
+        showClipPlane: ShowClipPlane
       };
     };
   }

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -407,6 +407,34 @@ const CAMERA_FORM = {
   }
 };
 
+const CLIP_VIEW_FORM = {
+  title: 'Clip View Settings',
+  schema: {
+    type: 'object',
+    required: ['Enabled'],
+    additionalProperties: false,
+    properties: {
+      Enabled: {
+        type: 'boolean',
+        description: 'Whether the clip view is enabled or not'
+      }
+    }
+  },
+  default: (panel: JupyterCadPanel) => {
+    return {
+      Enabled: panel.clipView?.enabled ?? false
+    };
+  },
+  syncData: (panel: JupyterCadPanel) => {
+    return (props: IDict) => {
+      const { Enabled } = props;
+      panel.clipView = {
+        enabled: Enabled
+      };
+    };
+  }
+};
+
 const EXPORT_FORM = {
   title: 'Export to .jcad',
   schema: {
@@ -686,6 +714,29 @@ export function addCommands(
     }
   });
 
+  commands.addCommand(CommandIDs.updateClipView, {
+    label: trans.__('Clip View'),
+    isEnabled: () => Boolean(tracker.currentWidget),
+    iconClass: 'fa fa-paperclip',
+    execute: async () => {
+      const current = tracker.currentWidget;
+
+      if (!current) {
+        return;
+      }
+
+      const dialog = new FormDialog({
+        context: current.context,
+        title: CLIP_VIEW_FORM.title,
+        schema: CLIP_VIEW_FORM.schema,
+        sourceData: CLIP_VIEW_FORM.default(current.content),
+        syncData: CLIP_VIEW_FORM.syncData(current.content),
+        cancelButton: true
+      });
+      await dialog.launch();
+    }
+  });
+
   commands.addCommand(CommandIDs.exportJcad, {
     label: trans.__('Export to .jcad'),
     isEnabled: () => {
@@ -737,6 +788,7 @@ export namespace CommandIDs {
   export const updateAxes = 'jupytercad:updateAxes';
   export const updateExplodedView = 'jupytercad:updateExplodedView';
   export const updateCameraSettings = 'jupytercad:updateCameraSettings';
+  export const updateClipView = 'jupytercad:updateClipView';
 
   export const exportJcad = 'jupytercad:exportJcad';
 }

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -422,7 +422,7 @@ const CLIP_VIEW_FORM = {
       ShowClipPlane: {
         type: 'boolean',
         description: 'Whether the clip plane should be rendered or not'
-      },
+      }
     }
   },
   default: (panel: JupyterCadPanel) => {

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -417,12 +417,12 @@ export class MainView extends React.Component<IProps, IStates> {
   startAnimationLoop = (): void => {
     this._requestID = window.requestAnimationFrame(this.startAnimationLoop);
 
-    if (this._clipPlane !== null) {
-      this._clippingPlane.coplanarPoint(this._clipPlane.position);
-      this._clipPlane.lookAt(
-        this._clipPlane.position.x - this._clippingPlane.normal.x,
-        this._clipPlane.position.y - this._clippingPlane.normal.y,
-        this._clipPlane.position.z - this._clippingPlane.normal.z
+    if (this._clippingPlaneMesh !== null) {
+      this._clippingPlane.coplanarPoint(this._clippingPlaneMesh.position);
+      this._clippingPlaneMesh.lookAt(
+        this._clippingPlaneMesh.position.x - this._clippingPlane.normal.x,
+        this._clippingPlaneMesh.position.y - this._clippingPlane.normal.y,
+        this._clippingPlaneMesh.position.z - this._clippingPlane.normal.z
       );
     }
 
@@ -847,18 +847,16 @@ export class MainView extends React.Component<IProps, IStates> {
       stencilZPass: THREE.ReplaceStencilOp,
       side: THREE.DoubleSide
     });
-    this._clipPlane = new THREE.Mesh(planeGeom, planeMat);
-    this._clipPlane.onAfterRender = function (renderer) {
+    this._clippingPlaneMesh = new THREE.Mesh(planeGeom, planeMat);
+    this._clippingPlaneMesh.onAfterRender = function (renderer) {
       renderer.clearStencil();
     };
 
-    this._scene.add(this._clipPlane);
+    this._scene.add(this._clippingPlaneMesh);
     this._scene.add(this._meshGroup);
 
     this.setState(old => ({ ...old, loading: false }));
   };
-
-  private _clipPlane: THREE.Mesh | null = null;
 
   private _updateRefLength(force = false): void {
     if (this._meshGroup) {
@@ -1482,6 +1480,7 @@ export class MainView extends React.Component<IProps, IStates> {
   private _explodedViewLinesHelperGroup: THREE.Group | null = null; // The list of line helpers for the exploded view
   private _cameraSettings: CameraSettings = { type: 'Perspective' };
   private _clipSettings: ClipSettings = { enabled: false };
+  private _clippingPlaneMesh: THREE.Mesh | null = null;
   private _clippingPlane = new THREE.Plane(new THREE.Vector3(-1, 0, 0), 0);
   private _clippingPlanes = [this._clippingPlane];
 

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -286,6 +286,13 @@ export class MainView extends React.Component<IProps, IStates> {
         this._contextMenu.open(e);
       });
 
+      document.addEventListener('keydown', e => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this._onKeyDown.bind(this)(e);
+      });
+
       const controls = new OrbitControls(
         this._camera,
         this._renderer.domElement
@@ -618,6 +625,21 @@ export class MainView extends React.Component<IProps, IStates> {
       this._model.syncSelectedObject(names, this.state.id);
     }
   }
+
+  private _onKeyDown(event: KeyboardEvent) {
+    if (this._clipSettings.enabled) {
+      switch (event.key) {
+        case 'r':
+          if (this._transformControls.mode === 'rotate') {
+            this._transformControls.setMode('translate');
+          } else {
+            this._transformControls.setMode('rotate');
+          }
+          break;
+      }
+    }
+  }
+
   private _saveMeta = (payload: IDisplayShape['payload']['result']) => {
     if (!this._model) {
       return;
@@ -626,6 +648,7 @@ export class MainView extends React.Component<IProps, IStates> {
       this._model.sharedModel.setShapeMeta(objName, data.meta);
     });
   };
+
   private _shapeToMesh = (payload: IDisplayShape['payload']['result']) => {
     if (this._meshGroup !== null) {
       this._scene.remove(this._meshGroup);

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -1337,7 +1337,7 @@ export class MainView extends React.Component<IProps, IStates> {
       this._renderer.localClippingEnabled = true;
       this._transformControls.enabled = true;
       this._transformControls.visible = true;
-      this._clippingPlaneMeshControl.visible = true;
+      this._clippingPlaneMeshControl.visible = this._clipSettings.showClipPlane;
     } else {
       this._renderer.localClippingEnabled = false;
       this._transformControls.enabled = false;
@@ -1497,7 +1497,7 @@ export class MainView extends React.Component<IProps, IStates> {
   private _explodedView: ExplodedView = { enabled: false, factor: 0 };
   private _explodedViewLinesHelperGroup: THREE.Group | null = null; // The list of line helpers for the exploded view
   private _cameraSettings: CameraSettings = { type: 'Perspective' };
-  private _clipSettings: ClipSettings = { enabled: false };
+  private _clipSettings: ClipSettings = { enabled: false, showClipPlane: true };
   private _clippingPlaneMeshControl: THREE.Mesh; // Plane mesh using for controlling the clip plane in the UI
   private _clippingPlaneMesh: THREE.Mesh | null = null; // Plane mesh used for "filling the gaps"
   private _clippingPlane = new THREE.Plane(new THREE.Vector3(-1, 0, 0), 0); // Mathematical object for clipping computation

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -387,7 +387,20 @@ export class MainView extends React.Component<IProps, IStates> {
     if (intersects.length > 0) {
       // Find the first intersection with a visible object
       for (const intersect of intersects) {
+        // Object is hidden
         if (!intersect.object.visible || !intersect.object.parent?.visible) {
+          continue;
+        }
+
+        // Object is clipped
+        const planePoint = new THREE.Vector3();
+        this._clippingPlane.coplanarPoint(planePoint);
+        planePoint.sub(intersect.point);
+
+        if (
+          this._clipSettings.enabled &&
+          planePoint.dot(this._clippingPlane.normal) > 0
+        ) {
           continue;
         }
 
@@ -591,24 +604,7 @@ export class MainView extends React.Component<IProps, IStates> {
       }
 
       // If clipping is enabled and picked position is hidden
-      // TODO This approach has its limitations. Users cannot select through a hidden part of the mesh.
-      // Doing the picking using color picking (going through the GPU pipeline instead of doing it on the CPU)
-      // can fix it
-      const planePoint = new THREE.Vector3();
-      this._clippingPlane.coplanarPoint(planePoint);
-      planePoint.sub(picked.position);
-
-      if (
-        this._clipSettings.enabled &&
-        planePoint.dot(this._clippingPlane.normal) > 0
-      ) {
-        if (this._pointer3D) {
-          this._pointer3D.mesh.visible = false;
-        }
-        this._syncPointer(undefined, undefined);
-      } else {
-        this._syncPointer(picked.position, picked.mesh.name);
-      }
+      this._syncPointer(picked.position, picked.mesh.name);
     } else {
       if (this._pointer3D) {
         this._pointer3D.mesh.visible = false;

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -34,7 +34,7 @@ import { v4 as uuid } from 'uuid';
 
 import { FloatingAnnotation } from './annotation/view';
 import { getCSSVariableColor, throttle } from './tools';
-import { AxeHelper, CameraSettings, ExplodedView } from './types';
+import { AxeHelper, CameraSettings, ExplodedView, ClipSettings } from './types';
 
 // Apply the BVH extension
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
@@ -1085,6 +1085,14 @@ export class MainView extends React.Component<IProps, IStates> {
 
         this._updateCamera();
       }
+    }
+
+    if (change.key === 'clipView') {
+      const clipSettings = change.newValue as ClipSettings | undefined;
+
+      console.log(clipSettings);
+
+      // if (change.type)
     }
   }
 

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -332,8 +332,7 @@ export class MainView extends React.Component<IProps, IStates> {
         this._renderer.domElement
       );
 
-      // Dumb geometry for the controls when using it for the clip plane
-      // (the clip plane being just a mathematical plane that is not visible in the screen)
+      // Create half transparent plane mesh for controls
       this._clippingPlaneMeshControl = new THREE.Mesh(
         new THREE.PlaneGeometry(1, 1),
         new THREE.MeshBasicMaterial({

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -823,11 +823,8 @@ export class MainView extends React.Component<IProps, IStates> {
       this._refLength! * 10, // *10 is a bit arbitrary and extreme but that does not impact performance or anything
       this._refLength! * 10
     );
-    const planeMat = new THREE.MeshStandardMaterial({
+    const planeMat = new THREE.MeshPhongMaterial({
       color: DEFAULT_EDGE_COLOR,
-      metalness: 0.1,
-      roughness: 0.75,
-
       stencilWrite: true,
       stencilRef: 0,
       stencilFunc: THREE.NotEqualStencilFunc,

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -824,7 +824,7 @@ export class MainView extends React.Component<IProps, IStates> {
       this._refLength! * 10
     );
     const planeMat = new THREE.MeshStandardMaterial({
-      color: 0xe91e63,
+      color: DEFAULT_EDGE_COLOR,
       metalness: 0.1,
       roughness: 0.75,
 

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -1268,11 +1268,13 @@ export class MainView extends React.Component<IProps, IStates> {
       this._explodedViewLinesHelperGroup?.removeFromParent();
       this._explodedViewLinesHelperGroup = new THREE.Group();
 
-      for (const mesh of this._meshGroup?.children as BasicMesh[]) {
-        const explodedState = this._computeExplodedState(mesh);
+      for (const group of this._meshGroup?.children as THREE.Group[]) {
+        const explodedState = this._computeExplodedState(
+          group.getObjectByName('main') as BasicMesh
+        );
 
-        mesh.position.set(0, 0, 0);
-        mesh.translateOnAxis(explodedState.vector, explodedState.distance);
+        group.position.set(0, 0, 0);
+        group.translateOnAxis(explodedState.vector, explodedState.distance);
 
         // Draw lines
         const material = new THREE.LineBasicMaterial({
@@ -1284,8 +1286,8 @@ export class MainView extends React.Component<IProps, IStates> {
           explodedState.newGeometryCenter
         ]);
         const line = new THREE.Line(geometry, material);
-        line.name = mesh.name;
-        line.visible = mesh.visible;
+        line.name = group.name;
+        line.visible = group.visible;
 
         this._explodedViewLinesHelperGroup.add(line);
       }

--- a/packages/base/src/mainview.tsx
+++ b/packages/base/src/mainview.tsx
@@ -405,11 +405,11 @@ export class MainView extends React.Component<IProps, IStates> {
     this._requestID = window.requestAnimationFrame(this.startAnimationLoop);
 
     if (this._clipPlane !== null) {
-      this._clippingPlane.coplanarPoint( this._clipPlane.position );
+      this._clippingPlane.coplanarPoint(this._clipPlane.position);
       this._clipPlane.lookAt(
         this._clipPlane.position.x - this._clippingPlane.normal.x,
         this._clipPlane.position.y - this._clippingPlane.normal.y,
-        this._clipPlane.position.z - this._clippingPlane.normal.z,
+        this._clipPlane.position.z - this._clippingPlane.normal.z
       );
     }
 
@@ -834,7 +834,7 @@ export class MainView extends React.Component<IProps, IStates> {
       stencilFail: THREE.ReplaceStencilOp,
       stencilZFail: THREE.ReplaceStencilOp,
       stencilZPass: THREE.ReplaceStencilOp,
-      side: THREE.DoubleSide,
+      side: THREE.DoubleSide
     });
     this._clipPlane = new THREE.Mesh(planeGeom, planeMat);
     this._clipPlane.onAfterRender = function (renderer) {

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -170,6 +170,14 @@ export class ToolbarWidget extends Toolbar {
           commands: options.commands
         })
       );
+      this.addItem(
+        'Clip View',
+        new CommandToolbarButton({
+          id: CommandIDs.updateClipView,
+          label: '',
+          commands: options.commands
+        })
+      );
       this.addItem('separator5', new Separator());
       (options.externalCommands ?? []).forEach(cmd => {
         this.addItem(

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -15,6 +15,7 @@ import minimizeIconStr from '../style/icon/minimize.svg';
 import sphereIconStr from '../style/icon/sphere.svg';
 import torusIconStr from '../style/icon/torus.svg';
 import unionIconStr from '../style/icon/union.svg';
+import clippingIconStr from '../style/icon/clipping.svg';
 
 export const jcLightIcon = new LabIcon({
   name: 'jupytercad:control-light',
@@ -79,6 +80,11 @@ export const axesIcon = new LabIcon({
 export const explodedViewIcon = new LabIcon({
   name: 'jupytercad:explodedView-icon',
   svgstr: jvControlLight
+});
+
+export const clippingIcon = new LabIcon({
+  name: 'jupytercad:clipping-icon',
+  svgstr: clippingIconStr
 });
 
 export const debounce = (

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -28,6 +28,13 @@ export type CameraSettings = {
   type: 'Perspective' | 'Orthographic';
 };
 
+/**
+ * The state of the clip view
+ */
+export type ClipSettings = {
+  enabled: boolean;
+};
+
 export interface IControlPanelModel {
   disconnect(f: any): void;
   documentChanged: ISignal<IJupyterCadTracker, IJupyterCadWidget | null>;

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -33,6 +33,7 @@ export type CameraSettings = {
  */
 export type ClipSettings = {
   enabled: boolean;
+  showClipPlane: boolean;
 };
 
 export interface IControlPanelModel {

--- a/packages/base/src/widget.tsx
+++ b/packages/base/src/widget.tsx
@@ -7,7 +7,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import * as React from 'react';
 
 import { MainView } from './mainview';
-import { AxeHelper, CameraSettings, ExplodedView } from './types';
+import { AxeHelper, CameraSettings, ExplodedView, ClipSettings } from './types';
 import { IJCadWorkerRegistry, IJupyterCadWidget } from '@jupytercad/schema';
 
 export class JupyterCadWidget
@@ -90,6 +90,14 @@ export class JupyterCadPanel extends ReactWidget {
 
   set cameraSettings(value: CameraSettings | undefined) {
     this._view.set('cameraSettings', value || null);
+  }
+
+  get clipView(): ClipSettings | undefined {
+    return this._view.get('clipView') as ClipSettings | undefined;
+  }
+
+  set clipView(value: ClipSettings | undefined) {
+    this._view.set('clipView', value || null);
   }
 
   deleteAxes(): void {

--- a/packages/base/style/icon/clipping.svg
+++ b/packages/base/style/icon/clipping.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24px"
+   viewBox="0 0 24 24"
+   width="24px"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="clipping.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="78.541667"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="3840"
+     inkscape:window-height="2091"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <g
+     class="jp-icon3"
+     fill="#616161"
+     id="g6">
+    <g
+       id="g5">
+      <path
+         d="M2,6c0.55,0,1-0.45,1-1V4c0-0.55,0.45-1,1-1h1c0.55,0,1-0.45,1-1S5.55,1,5,1H4C2.34,1,1,2.34,1,4v1C1,5.55,1.45,6,2,6z"
+         id="path1" />
+      <path
+         d="M5,21H4c-0.55,0-1-0.45-1-1v-1c0-0.55-0.45-1-1-1c-0.55,0-1,0.45-1,1v1c0,1.66,1.34,3,3,3h1c0.55,0,1-0.45,1-1 S5.55,21,5,21z"
+         id="path2" />
+      <path
+         d="M20,1h-1c-0.55,0-1,0.45-1,1s0.45,1,1,1h1c0.55,0,1,0.45,1,1v1c0,0.55,0.45,1,1,1c0.55,0,1-0.45,1-1V4 C23,2.34,21.66,1,20,1z"
+         id="path3" />
+      <path
+         d="M22,18c-0.55,0-1,0.45-1,1v1c0,0.55-0.45,1-1,1h-1c-0.55,0-1,0.45-1,1s0.45,1,1,1h1c1.66,0,3-1.34,3-3v-1 C23,18.45,22.55,18,22,18z"
+         id="path4" />
+      <path
+         d="M 19,14.87 V 9.13 C 19,8.41 18.62,7.75 18,7.4 L 13,4.52 C 12.69,4.34 12.35,4.25 12,4.25 c -0.35,0 -0.69,0.09 -1,0.27 L 6,7.39 C 5.38,7.75 5,8.41 5,9.13 v 5.74 c 0,0.72 0.38,1.38 1,1.73 l 5,2.88 c 0.31,0.18 0.65,0.27 1,0.27 0.35,0 0.69,-0.09 1,-0.27 l 5,-2.88 c 0.62,-0.35 1,-1.01 1,-1.73 z m -8,2.3 -4,-2.3 v -4.63 l 4,2.33 z M 12,10.84 8.04,8.53 12,6.25 15.96,8.53 Z"
+         id="path5"
+         sodipodi:nodetypes="ssccsccssccsccscccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/python/jupytercad_app/src/app/plugins/mainmenu/menuWidget.ts
+++ b/python/jupytercad_app/src/app/plugins/mainmenu/menuWidget.ts
@@ -163,6 +163,10 @@ export class MainMenu extends MenuBar {
       type: 'command',
       command: CommandIDs.updateCameraSettings
     });
+    menu.addItem({
+      type: 'command',
+      command: CommandIDs.updateClipView
+    });
 
     const themeMenu = new RankedMenu({
       commands: this._commands,


### PR DESCRIPTION
Remaining TODOs:
- [x] Have a nicer icon
- [x] Have keyboard shortcuts for switching from rotation mode to translate mode
- [x] Use stencil buffer to fill the shapes?

[Screencast from 2024-03-12 14-12-49.webm](https://github.com/jupytercad/jupytercad/assets/21197331/cc8c9817-f021-406a-a48f-a0fcd5e68883)
