### PR TITLE
Improve post-processing system

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@types/node": "^18.15.11",
+    "@types/three": "^0.135.0",
     "rimraf": "^3.0.2",
     "typescript": "^5"
   },

--- a/packages/base/src/3dview/helpers.ts
+++ b/packages/base/src/3dview/helpers.ts
@@ -1,8 +1,4 @@
-import {
-  IDict,
-  IParsedShape,
-  JCadWorkerSupportedFormat
-} from '@jupytercad/schema';
+import { IDict, IParsedShape } from '@jupytercad/schema';
 import * as THREE from 'three';
 import {
   acceleratedRaycast,
@@ -265,15 +261,4 @@ export function buildShape(options: {
   meshGroup.add(mainMesh);
 
   return { meshGroup, mainMesh, edgesMeshes };
-}
-
-export function parseShapeName(name?: string): {
-  format?: JCadWorkerSupportedFormat;
-  workerId?: string;
-} {
-  if (!name) {
-    return {};
-  }
-  const [_, format, workerId] = name.split('::');
-  return { format, workerId } as any;
 }

--- a/packages/base/src/3dview/helpers.ts
+++ b/packages/base/src/3dview/helpers.ts
@@ -1,4 +1,8 @@
-import { IDict, IParsedShape } from '@jupytercad/schema';
+import {
+  IDict,
+  IParsedShape,
+  JCadWorkerSupportedFormat
+} from '@jupytercad/schema';
 import * as THREE from 'three';
 import {
   acceleratedRaycast,
@@ -261,4 +265,15 @@ export function buildShape(options: {
   meshGroup.add(mainMesh);
 
   return { meshGroup, mainMesh, edgesMeshes };
+}
+
+export function parseShapeName(name?: string): {
+  format?: JCadWorkerSupportedFormat;
+  workerId?: string;
+} {
+  if (!name) {
+    return {};
+  }
+  const [_, format, workerId] = name.split('::');
+  return { format, workerId } as any;
 }

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -20,6 +20,7 @@ import * as React from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader';
 
 import { FloatingAnnotation } from '../annotation';
@@ -49,7 +50,7 @@ import {
 } from './helpers';
 import { MainViewModel } from './mainviewmodel';
 import { Spinner } from './spinner';
-import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
+
 interface IProps {
   viewModel: MainViewModel;
 }
@@ -730,7 +731,8 @@ export class MainView extends React.Component<IProps, IStates> {
     if (shapes !== null && shapes !== undefined) {
       this._shapeToMesh(renderData.shapes);
       const options = {
-        binary: true
+        binary: true,
+        onlyVisible: false
       };
 
       if (postResult && this._meshGroup) {
@@ -749,7 +751,7 @@ export class MainView extends React.Component<IProps, IStates> {
           exporter.parse(
             threeShape,
             exported => {
-              pos.occBrep = exported as any;
+              pos.postShape = exported as any;
             },
             options
           );

--- a/packages/base/src/3dview/mainviewmodel.ts
+++ b/packages/base/src/3dview/mainviewmodel.ts
@@ -20,7 +20,6 @@ import { JSONValue } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
 import { v4 as uuid } from 'uuid';
-import { parseShapeName } from './helpers';
 
 export class MainViewModel implements IDisposable {
   constructor(options: MainViewModel.IOptions) {
@@ -93,7 +92,7 @@ export class MainViewModel implements IDisposable {
         const threejsPostResult: IDict<IPostOperatorInput> = {};
 
         Object.entries(postResult).forEach(([key, val]) => {
-          const { format } = parseShapeName(val.jcObject.shape);
+          const format = val.jcObject?.shapeMetadata?.shapeFormat;
           if (format === JCadWorkerSupportedFormat.BREP) {
             rawPostResult[key] = val;
           } else if (format === JCadWorkerSupportedFormat.GLTF) {
@@ -146,12 +145,14 @@ export class MainViewModel implements IDisposable {
         if (!shape) {
           return;
         }
-        const { format, workerId } = parseShapeName(shape);
+
+        const { shapeFormat, workerId } = res.jcObject?.shapeMetadata ?? {};
         const worker = this._workerRegistry.getWorker(workerId ?? '');
         if (wk !== worker) {
           return;
         }
-        if (wk.shapeFormat === format) {
+
+        if (wk.shapeFormat === shapeFormat) {
           wk.postMessage({
             id,
             action: WorkerAction.POSTPROCESS,

--- a/packages/occ-worker/src/occapi/postOperator.ts
+++ b/packages/occ-worker/src/occapi/postOperator.ts
@@ -7,10 +7,10 @@ import { getShapesFactory } from './common';
 export function _PostOperator(
   arg: IPostOperator,
   content: IJCadContent
-): { occBrep: string } {
+): { postShape: string } {
   const baseObject = content.objects.filter(obj => obj.name === arg.Object);
   if (baseObject.length === 0) {
-    return { occBrep: '' };
+    return { postShape: '' };
   }
   const shapesFactory = getShapesFactory();
   const baseShape = baseObject[0].shape;
@@ -20,9 +20,9 @@ export function _PostOperator(
       content
     );
     if (base?.occShape) {
-      const occBrep = _writeBrep(base.occShape);
-      return { occBrep };
+      const postShape = _writeBrep(base.occShape);
+      return { postShape };
     }
   }
-  return { occBrep: '' };
+  return { postShape: '' };
 }

--- a/packages/occ-worker/src/types.ts
+++ b/packages/occ-worker/src/types.ts
@@ -2,22 +2,22 @@ import { OCC } from '@jupytercad/opencascade';
 import {
   IAny,
   IBox,
+  IChamfer,
   ICone,
   ICut,
   ICylinder,
   IExtrusion,
+  IFillet,
   IFuse,
   IIntersection,
   IJCadContent,
+  IPostOperator,
   IShapeMetadata,
   ISketchObject,
   ISphere,
   ITorus,
-  IPostOperator,
-  WorkerAction,
   IWorkerMessageBase,
-  IChamfer,
-  IFillet
+  WorkerAction
 } from '@jupytercad/schema';
 
 export interface IDict<T = any> {
@@ -45,7 +45,7 @@ export type IWorkerMessage = ILoadFile | IRegister;
 export interface IOperatorFuncOutput {
   occShape?: OCC.TopoDS_Shape;
   metadata?: IShapeMetadata | undefined;
-  occBrep?: string;
+  postShape?: string | ArrayBuffer;
 }
 
 type IOperatorFunc<T> = (

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -215,7 +215,7 @@ export interface IParsedShape {
 
 export interface IPostOperatorInput {
   jcObject: IJCadObject;
-  occBrep?: string;
+  postShape?: string | ArrayBuffer;
 }
 
 /**

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -278,8 +278,13 @@ export type IMessageHandler =
   | ((msg: IMainMessageBase) => void)
   | ((msg: IMainMessageBase) => Promise<void>);
 
+export enum JCadWorkerSupportedFormat {
+  BREP = 'BREP',
+  GLTF = 'GLTF'
+}
 export interface IJCadWorker {
   ready: Promise<void>;
+  shapeFormat?: JCadWorkerSupportedFormat;
   postMessage(msg: IWorkerMessageBase): void;
   register(options: { messageHandler: IMessageHandler; thisArg?: any }): string;
   unregister(id: string): void;

--- a/packages/schema/src/schema/jcad.json
+++ b/packages/schema/src/schema/jcad.json
@@ -52,9 +52,14 @@
     "shapeMetadata": {
       "title": "IShapeMetadata",
       "type": "object",
-      "required": ["mass", "centerOfMass", "matrixOfInertia"],
       "additionalProperties": false,
       "properties": {
+        "shapeFormat": {
+          "type": "string"
+        },
+        "workerId": {
+          "type": "string"
+        },
         "mass": {
           "type": "number"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,7 +939,7 @@ __metadata:
     "@rjsf/core": ^4.2.0
     "@types/d3-color": ^3.1.0
     "@types/node": ^18.15.11
-    "@types/three": ^0.134.0
+    "@types/three": ^0.135.0
     d3-color: ^3.1.0
     react: ^18.0.1
     rimraf: ^3.0.2
@@ -3602,10 +3602,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/three@npm:^0.134.0":
-  version: 0.134.0
-  resolution: "@types/three@npm:0.134.0"
-  checksum: 4dc0463b3833fb81ac3645af47404349af6a0e69e3dae37ae9e84dc1ac237689d77c28a6066375e85665191d037843f4adc22d345ab8fe90a5008591f78e86d1
+"@types/three@npm:^0.135.0":
+  version: 0.135.0
+  resolution: "@types/three@npm:0.135.0"
+  checksum: 85977e55cc3d7a14be88816a50bcec4eb0f141876d3cdc6dd7870f72122605af87462d7583e950cd0ee6ab21949b8c1b8304a88174d536648deb8ef97968fa1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## User facing changes

This PR revamps the external worker system, allowing workers to select the data formats (`BREP` and `GLTF` for now) they want to receive. More over,  `JupyterCAD` will send the data to the requester, and not all workers as in the previous version.

## Code changes

- New enum in the `@jupytercad/schema` for the supported formats

```js
export enum JCadWorkerSupportedFormat {
  BREP = 'BREP',
  GLTF = 'GLTF'
}
```

- New properties in `IJCadObject.shapeMetadata`: `shapeFormat` and `workerId`, these properties are used to identify the external worker and its supported format.
- `IOperatorFuncOutput.occBrep` is renamed to `postShape`
- A new optional property `shapeFormat` in the `IJCadWorker` format to indicate the supported geometry format of this worker

## Migration guide

-  Users need to update their worker class with the `shapeFormat` property if they want to use other formats than `BREP`, e.g.

```js
export class SalomeWorker implements IJCadWorker {
  constructor(options: SalomeWorker.IOptions) {
    this._appClient = options.appClient;
    this._tracker = options.tracker;
  }

  shapeFormat = JCadWorkerSupportedFormat.GLTF;
...
```
- The custom object added to the `jcad` document needs to have the `shapeMetadata` key containing `shapeFormat` and the worker ID (which is the ID when you register the worker with `workerRegistry.registerWorker` ), e.g.

```js
    const worker = new SalomeWorker({ appClient, tracker });
    workerRegistry.registerWorker(WORKER_ID, worker);
...
    const objectModel: IJCadObject = {
      shape: 'Post::SalomeMesh' as any,
      parameters,
      visible: true,
      name: Name,
      shapeMetadata: {
        shapeFormat: JCadWorkerSupportedFormat.GLTF,
        workerId: WORKER_ID
      }
    };
    sharedModel.transact(() => {
     sharedModel.addObject(objectModel);
    });
```