### PR TITLE
Add await for postShape before sending

### DIFF
--- a/packages/base/src/3dview/mainviewmodel.ts
+++ b/packages/base/src/3dview/mainviewmodel.ts
@@ -117,7 +117,7 @@ export class MainViewModel implements IDisposable {
             postShapes: null,
             postResult: threejsPostResult
           });
-          this.sendRawGeomeryToWorker(rawPostResult);
+          this.sendRawGeometryToWorker(rawPostResult);
         }
 
         break;
@@ -138,7 +138,7 @@ export class MainViewModel implements IDisposable {
     }
   };
 
-  sendRawGeomeryToWorker(postResult: IDict<IPostOperatorInput>): void {
+  sendRawGeometryToWorker(postResult: IDict<IPostOperatorInput>): void {
     Object.values(postResult).forEach(res => {
       this._postWorkerId.forEach((wk, id) => {
         const shape = res.jcObject.shape;


### PR DESCRIPTION
Wait for the `GLTFExporter` callback to populate `postShape` before sending `postResult` to worker threads.