### PR TITLE
Fix dry-run logic so that it does not run on the first load of the file

### DIFF
--- a/packages/occ-worker/src/actions.ts
+++ b/packages/occ-worker/src/actions.ts
@@ -63,11 +63,11 @@ function buildModel(
   return outputModel;
 }
 
-function loadFile(payload: { content: IJCadContent }): IDict | null {
+function loadFile(payload: { content: IJCadContent }, load_on_failure=false): IDict | null {
   const { content } = payload;
   const outputModel = buildModel(content);
 
-  const parser = new OccParser(outputModel);
+  const parser = new OccParser(outputModel, load_on_failure);
   const result = parser.execute();
   const postResult: IDict<IPostOperatorInput> = {};
   outputModel.forEach(item => {
@@ -82,9 +82,14 @@ function loadFile(payload: { content: IJCadContent }): IDict | null {
   return { result, postResult };
 }
 
+function dryRun(payload: { content: IJCadContent }) {
+  return loadFile(payload, true);
+}
+
 const WorkerHandler: {
   [key in WorkerAction]: (payload: any) => any;
 } = {} as any;
 WorkerHandler[WorkerAction.LOAD_FILE] = loadFile;
+WorkerHandler[WorkerAction.DRY_RUN] = dryRun;
 
 export default WorkerHandler;

--- a/packages/occ-worker/src/actions.ts
+++ b/packages/occ-worker/src/actions.ts
@@ -70,8 +70,8 @@ function loadFile(
   const { content } = payload;
   const outputModel = buildModel(content);
 
-  const parser = new OccParser(outputModel, raiseOnFailure);
-  const result = parser.execute();
+  const parser = new OccParser(outputModel);
+  const result = parser.execute(raiseOnFailure);
   const postResult: IDict<IPostOperatorInput> = {};
   outputModel.forEach(item => {
     if (item.jcObject.shape?.startsWith('Post::')) {

--- a/packages/occ-worker/src/actions.ts
+++ b/packages/occ-worker/src/actions.ts
@@ -63,7 +63,10 @@ function buildModel(
   return outputModel;
 }
 
-function loadFile(payload: { content: IJCadContent }, load_on_failure=false): IDict | null {
+function loadFile(
+  payload: { content: IJCadContent },
+  load_on_failure = false
+): IDict | null {
   const { content } = payload;
   const outputModel = buildModel(content);
 

--- a/packages/occ-worker/src/actions.ts
+++ b/packages/occ-worker/src/actions.ts
@@ -65,12 +65,12 @@ function buildModel(
 
 function loadFile(
   payload: { content: IJCadContent },
-  load_on_failure = false
+  raiseOnFailure = false
 ): IDict | null {
   const { content } = payload;
   const outputModel = buildModel(content);
 
-  const parser = new OccParser(outputModel, load_on_failure);
+  const parser = new OccParser(outputModel, raiseOnFailure);
   const result = parser.execute();
   const postResult: IDict<IPostOperatorInput> = {};
   outputModel.forEach(item => {

--- a/packages/occ-worker/src/occapi/operatorCache.ts
+++ b/packages/occ-worker/src/occapi/operatorCache.ts
@@ -154,7 +154,9 @@ export function operatorCache<T>(
   return (
     args: T,
     content: IJCadContent
-  ): { occShape: OCC.TopoDS_Shape; metadata?: IShapeMetadata | undefined } => {
+  ):
+    | { occShape: OCC.TopoDS_Shape; metadata?: IShapeMetadata | undefined }
+    | undefined => {
     const expandedArgs = expand_operator(name, args, content);
     const hash = `${hashCode(JSON.stringify(expandedArgs))}`;
     if (SHAPE_CACHE.has(hash)) {
@@ -168,10 +170,6 @@ export function operatorCache<T>(
         };
         SHAPE_CACHE.set(hash, cacheData);
         return cacheData;
-      } else {
-        throw new Error(
-          `Unknown error while creating ${name}: ${JSON.stringify(content)}`
-        );
       }
     }
   };

--- a/packages/occ-worker/src/occparser.ts
+++ b/packages/occ-worker/src/occparser.ts
@@ -11,7 +11,7 @@ interface IShapeList {
 export class OccParser {
   private _shapeList: IShapeList[];
   private _occ: OCC.OpenCascadeInstance = (self as any).occ;
-  private raise_on_failure: boolean;
+  private raiseOnFailure: boolean;
 
   constructor(shapeList: IShapeList[], raise_on_failure = false) {
     this._shapeList = shapeList;

--- a/packages/occ-worker/src/occparser.ts
+++ b/packages/occ-worker/src/occparser.ts
@@ -11,8 +11,11 @@ interface IShapeList {
 export class OccParser {
   private _shapeList: IShapeList[];
   private _occ: OCC.OpenCascadeInstance = (self as any).occ;
-  constructor(shapeList: IShapeList[]) {
+  private raise_on_failure: boolean;
+
+  constructor(shapeList: IShapeList[], raise_on_failure=false) {
     this._shapeList = shapeList;
+    this.raise_on_failure = raise_on_failure;
   }
 
   execute(): IDict<IParsedShape> {
@@ -22,7 +25,11 @@ export class OccParser {
       const { shapeData, jcObject } = data;
       const { occShape, metadata } = shapeData;
       if (!occShape) {
-        return;
+        if (this.raise_on_failure) {
+          throw Error("Unknown failure");
+        } else {
+          return;
+        }
       }
       new this._occ.BRepMesh_IncrementalMesh_2(
         occShape,

--- a/packages/occ-worker/src/occparser.ts
+++ b/packages/occ-worker/src/occparser.ts
@@ -16,7 +16,7 @@ export class OccParser {
     this._shapeList = shapeList;
   }
 
-  execute(raiseOnFailure=false): IDict<IParsedShape> {
+  execute(raiseOnFailure = false): IDict<IParsedShape> {
     const maxDeviation = 0.1;
     const threejsData: IDict<IParsedShape> = {};
     this._shapeList.forEach(data => {

--- a/packages/occ-worker/src/occparser.ts
+++ b/packages/occ-worker/src/occparser.ts
@@ -13,7 +13,7 @@ export class OccParser {
   private _occ: OCC.OpenCascadeInstance = (self as any).occ;
   private raise_on_failure: boolean;
 
-  constructor(shapeList: IShapeList[], raise_on_failure=false) {
+  constructor(shapeList: IShapeList[], raise_on_failure = false) {
     this._shapeList = shapeList;
     this.raise_on_failure = raise_on_failure;
   }
@@ -26,7 +26,7 @@ export class OccParser {
       const { occShape, metadata } = shapeData;
       if (!occShape) {
         if (this.raise_on_failure) {
-          throw Error("Unknown failure");
+          throw Error('Unknown failure');
         } else {
           return;
         }

--- a/packages/occ-worker/src/occparser.ts
+++ b/packages/occ-worker/src/occparser.ts
@@ -11,21 +11,19 @@ interface IShapeList {
 export class OccParser {
   private _shapeList: IShapeList[];
   private _occ: OCC.OpenCascadeInstance = (self as any).occ;
-  private raiseOnFailure: boolean;
 
-  constructor(shapeList: IShapeList[], raise_on_failure = false) {
+  constructor(shapeList: IShapeList[]) {
     this._shapeList = shapeList;
-    this.raise_on_failure = raise_on_failure;
   }
 
-  execute(): IDict<IParsedShape> {
+  execute(raiseOnFailure=false): IDict<IParsedShape> {
     const maxDeviation = 0.1;
     const threejsData: IDict<IParsedShape> = {};
     this._shapeList.forEach(data => {
       const { shapeData, jcObject } = data;
       const { occShape, metadata } = shapeData;
       if (!occShape) {
-        if (this.raise_on_failure) {
+        if (raiseOnFailure) {
           throw Error('Unknown failure');
         } else {
           return;

--- a/packages/occ-worker/src/worker.ts
+++ b/packages/occ-worker/src/worker.ts
@@ -57,7 +57,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
     }
     case WorkerAction.DRY_RUN: {
       try {
-        WorkerHandler[WorkerAction.LOAD_FILE](message.payload);
+        WorkerHandler[WorkerAction.DRY_RUN](message.payload);
       } catch (e) {
         let msg = '';
 


### PR DESCRIPTION
Fix https://github.com/jupytercad/JupyterCAD/issues/363

Some files are simply not fully supported by jupytercad yet, but we want to at least be able to partially open them (like the `ArchDetail.FCSTD` example).

This means we should not raise any error while loading those files in the worker and keep going if the resulting OCC shape of operators is not defined.

Error raising should only happen upon user interaction (creation of operators, changing of properties) so that we prevent users to create malformed files.


https://github.com/jupytercad/JupyterCAD/assets/21197331/896ac810-5533-4102-80f3-e27ced0b34c8

