### PR TITLE
Fix extrusion form defaults

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -272,7 +272,7 @@ const OPERATORS = {
       const sel0 = getSelectedMeshName(selected, 0);
       return {
         Name: newName('Extrusion', model),
-        Base: [sel0 || objects[0].name || ''],
+        Base: sel0 || objects[0].name || '',
         Dir: [0, 0, 1],
         LengthFwd: 10,
         LengthRev: 0,


### PR DESCRIPTION
Fix #367 

The default value for `Base` was a list instead of a string