### PR TITLE
Remove unneeded jupytercad_lab dependencies

### DIFF
--- a/python/jupytercad_lab/pyproject.toml
+++ b/python/jupytercad_lab/pyproject.toml
@@ -23,10 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "jupyter_server>=2.0.1,<3",
-  "jupyter-ydoc>=2,<3",
-  "jupyterlab>=4,<5",
-  "jupyter-collaboration>=2.1.0,<3",
+  "pycrdt",
   "ypywidgets>=0.9.0,<0.10.0",
   "yjs-widgets>=0.3.5,<0.4",
   "comm>=0.1.2,<0.2.0",


### PR DESCRIPTION
This was having the downside of not being able to install it in an `emscripten-wasm32` env:

```
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    └─ jupytercad_lab is not installable because there are no viable options
       ├─ jupytercad_lab [1.0.0|1.0.1] would require
       │  └─ y-py >=0.6,<0.7 , which does not exist (perhaps a missing channel);
       └─ jupytercad_lab [2.0.0|2.0.1|2.0.2] would require
          └─ jupyterlab >=4,<5 , which requires
             └─ tornado >=6.2.0 , which does not exist (perhaps a missing channel).
```