### PR TITLE
Update jupyter-collaboration v3.0.0-beta.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build:app": "lerna run --ignore @jupytercad/jupytercad-lab build"
   },
   "resolutions": {
+    "@jupyter/collaboration": "^3.0.0-beta.8",
     "@jupyterlab/apputils": "^4.0.0",
     "@lumino/coreutils": "^2.0.0",
     "@jupyterlab/notebook": "^4.0.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@deathbeds/jupyterlab-rjsf": "^1.1.0",
     "@jupyter/collaborative-drive": "^3.0.0-beta.8",
-    "@jupyter/ydoc": "^1.0.0",
+    "@jupyter/ydoc": "^3.0.0-a9",
     "@jupytercad/occ-worker": "^3.0.0-alpha.3",
     "@jupytercad/schema": "^3.0.0-alpha.3",
     "@jupyterlab/application": "^4.0.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@deathbeds/jupyterlab-rjsf": "^1.1.0",
-    "@jupyter/docprovider": "^2.0.0",
+    "@jupyter/collaborative-drive": "^3.0.0-beta.8",
     "@jupyter/ydoc": "^1.0.0",
     "@jupytercad/occ-worker": "^3.0.0-alpha.3",
     "@jupytercad/schema": "^3.0.0-alpha.3",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
-    "@jupyter/ydoc": "^1.0.0",
+    "@jupyter/ydoc": "^3.0.0-a9",
     "@jupyterlab/apputils": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
     "@jupyterlab/docregistry": "^4.0.0",

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -1,5 +1,5 @@
 import { MapChange, YDocument } from '@jupyter/ydoc';
-import { JSONExt, JSONObject } from '@lumino/coreutils';
+import { JSONExt, JSONObject, JSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import * as Y from 'yjs';
 
@@ -63,6 +63,42 @@ export class JupyterCadDoc
 
   get optionsChanged(): ISignal<IJupyterCadDoc, MapChange> {
     return this._optionsChanged;
+  }
+
+  getSource(): JSONValue | string {
+    const objects = this._objects.toJSON();
+    const options = this._options.toJSON();
+    const metadata = this._metadata.toJSON();
+    const outputs = this._outputs.toJSON();
+
+    return { objects, options, metadata, outputs };
+  }
+
+  setSource(value: JSONValue): void {
+    if (!value) {
+      return;
+    }
+    this.transact(() => {
+      const objects = value['objects'] ?? [];
+      objects.forEach(obj => {
+        this._objects.push([new Y.Map(Object.entries(obj))]);
+      });
+
+      const options = value['options'] ?? {};
+      Object.entries(options).forEach(([key, val]) =>
+        this._options.set(key, val)
+      );
+
+      const metadata = value['metadata'] ?? {};
+      Object.entries(metadata).forEach(([key, val]) =>
+        this._metadata.set(key, val as string)
+      );
+
+      const outputs = value['outputs'] ?? {};
+      Object.entries(outputs).forEach(([key, val]) =>
+        this._outputs.set(key, val as IPostResult)
+      );
+    });
   }
 
   get metadataChanged(): ISignal<IJupyterCadDoc, MapChange> {

--- a/python/jupytercad_app/package.json
+++ b/python/jupytercad_app/package.json
@@ -53,7 +53,7 @@
     "@codemirror/view": "^6.9.3",
     "@jupyter/collaboration": "^3.0.0-beta.8",
     "@jupyter/collaborative-drive": "^3.0.0-beta.8",
-    "@jupyter/ydoc": "^0.3.4 || ^1.0.2",
+    "@jupyter/ydoc": "^3.0.0-a9",
     "@jupytercad/base": "^3.0.0-alpha.3",
     "@jupytercad/schema": "^3.0.0-alpha.3",
     "@jupyterlab/application": "^4.0.0",

--- a/python/jupytercad_app/package.json
+++ b/python/jupytercad_app/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.9.3",
-    "@jupyter/collaboration": "^3.0.0-beta.6",
-    "@jupyter/docprovider": "^2.0.0",
+    "@jupyter/collaboration": "^3.0.0-beta.8",
+    "@jupyter/collaborative-drive": "^3.0.0-beta.8",
     "@jupyter/ydoc": "^0.3.4 || ^1.0.2",
     "@jupytercad/base": "^3.0.0-alpha.3",
     "@jupytercad/schema": "^3.0.0-alpha.3",

--- a/python/jupytercad_core/package.json
+++ b/python/jupytercad_core/package.json
@@ -53,7 +53,7 @@
     "build:worker:prod": "webpack --config worker.webpack.config.js --mode=production"
   },
   "dependencies": {
-    "@jupyter/docprovider": "^2.0.0",
+    "@jupyter/collaborative-drive": "^3.0.0-beta.8",
     "@jupytercad/base": "^3.0.0-alpha.3",
     "@jupytercad/occ-worker": "^3.0.0-alpha.3",
     "@jupytercad/schema": "^3.0.0-alpha.3",
@@ -115,7 +115,7 @@
         "singleton": true,
         "bundled": true
       },
-      "@jupyter/docprovider": {
+      "@jupyter/collaborative-drive": {
         "singleton": true,
         "bundled": false
       }

--- a/python/jupytercad_core/pyproject.toml
+++ b/python/jupytercad_core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
   "jupyter_server>=2.0.6,<3",
   "jupyter_ydoc>=2,<3",
-  "jupyter-collaboration>=3.0.0b6,<4",
+  "jupyter-collaboration>=3.0.0b8,<4",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 license = {file = "LICENSE"}

--- a/python/jupytercad_core/src/jcadplugin/plugins.ts
+++ b/python/jupytercad_core/src/jcadplugin/plugins.ts
@@ -1,7 +1,7 @@
 import {
   ICollaborativeDrive,
   SharedDocumentFactory
-} from '@jupyter/docprovider';
+} from '@jupyter/collaborative-drive';
 import { logoIcon } from '@jupytercad/base';
 import {
   IAnnotationModel,

--- a/python/jupytercad_core/src/stepplugin/plugins.ts
+++ b/python/jupytercad_core/src/stepplugin/plugins.ts
@@ -1,7 +1,7 @@
 import {
   ICollaborativeDrive,
   SharedDocumentFactory
-} from '@jupyter/docprovider';
+} from '@jupyter/collaborative-drive';
 import {
   IJCadWorkerRegistry,
   IJCadWorkerRegistryToken,

--- a/python/jupytercad_core/src/stlplugin/plugins.ts
+++ b/python/jupytercad_core/src/stlplugin/plugins.ts
@@ -1,7 +1,7 @@
 import {
   ICollaborativeDrive,
   SharedDocumentFactory
-} from '@jupyter/docprovider';
+} from '@jupyter/collaborative-drive';
 import {
   IJCadWorkerRegistry,
   IJCadWorkerRegistryToken,

--- a/python/jupytercad_lab/package.json
+++ b/python/jupytercad_lab/package.json
@@ -51,7 +51,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyter/docprovider": "^2.0.0",
+    "@jupyter/collaborative-drive": "^3.0.0-beta.8",
     "@jupytercad/base": "^3.0.0-alpha.3",
     "@jupytercad/jupytercad-core": "^3.0.0-alpha.3",
     "@jupytercad/schema": "^3.0.0-alpha.3",
@@ -113,7 +113,7 @@
         "singleton": true,
         "bundled": false
       },
-      "@jupyter/docprovider": {
+      "@jupyter/collaborative-drive": {
         "singleton": true,
         "bundled": false
       },

--- a/python/jupytercad_lab/src/notebookrenderer.ts
+++ b/python/jupytercad_lab/src/notebookrenderer.ts
@@ -1,4 +1,4 @@
-import { ICollaborativeDrive } from '@jupyter/docprovider';
+import { ICollaborativeDrive } from '@jupyter/collaborative-drive';
 import { JupyterCadPanel } from '@jupytercad/base';
 import {
   IJCadWorkerRegistry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,13 +104,13 @@ __metadata:
   linkType: hard
 
 "@babel/parser@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/parser@npm:7.25.7"
+  version: 7.25.8
+  resolution: "@babel/parser@npm:7.25.8"
   dependencies:
-    "@babel/types": ^7.25.7
+    "@babel/types": ^7.25.8
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 7c40c2881e92415f5f2a88ac1078a8fea7f2b10097e76116ce40bfe01443d3a842c704bdb64d7b54c9e9dbbf49a60a0e1cf79ff35bcd02c52ff424179acd4259
+  checksum: c33f6d26542f156927c5dbe131265c791177d271e582338e960f803903086ec5c152bf25deae5f4c061b7bee14dc0b5fd2882ccb5a21c16ee0738d24fcc0406e
   languageName: node
   linkType: hard
 
@@ -160,14 +160,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/types@npm:7.25.7"
+"@babel/types@npm:^7.25.7, @babel/types@npm:^7.25.8":
+  version: 7.25.8
+  resolution: "@babel/types@npm:7.25.8"
   dependencies:
     "@babel/helper-string-parser": ^7.25.7
     "@babel/helper-validator-identifier": ^7.25.7
     to-fast-properties: ^2.0.0
-  checksum: a63a3ecdac5eb2fa10a75d50ec23d1560beed6c4037ccf478a430cc221ba9b8b3a55cfbaaefb6e997051728f3c02b44dcddb06de9a0132f164a0a597dd825731
+  checksum: 93d84858e820dbfa0fc4882b3ba6a421544d224ee61455a58eed0af9fc3518b30dc2166b8ba48cdd2e91083c5885ed773c36acf46d177b7b1fad9c35b6eb7639
   languageName: node
   linkType: hard
 
@@ -763,12 +763,12 @@ __metadata:
   linkType: hard
 
 "@jupyter/collaboration@npm:^2.0.0":
-  version: 2.1.2
-  resolution: "@jupyter/collaboration@npm:2.1.2"
+  version: 2.1.3
+  resolution: "@jupyter/collaboration@npm:2.1.3"
   dependencies:
     "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.7.0
-    "@jupyter/docprovider": ^2.1.2
+    "@jupyter/docprovider": ^2.1.3
     "@jupyterlab/apputils": ^4.0.5
     "@jupyterlab/coreutils": ^6.0.5
     "@jupyterlab/services": ^7.0.5
@@ -779,13 +779,13 @@ __metadata:
     react: ^18.2.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: 6c3b7a809eb7a57467e4fc6da96fe6e781972cb2608ccd509f9509e1d3329923fd88c320f0ebb219fd3a5bf5afcd8fd67205d326d74c0565b2938628e9a58e8e
+  checksum: 7239bb4e0b3e30c32a07aecc073882a56392c6a848c086630db392a4876d8bcb2fc658ef444892b73f58e1126a899fa704e41ddea649b4665c422412024ec76a
   languageName: node
   linkType: hard
 
-"@jupyter/collaboration@npm:^3.0.0-beta.6":
-  version: 3.0.0-beta.6
-  resolution: "@jupyter/collaboration@npm:3.0.0-beta.6"
+"@jupyter/collaboration@npm:^3.0.0-beta.8":
+  version: 3.0.0-beta.8
+  resolution: "@jupyter/collaboration@npm:3.0.0-beta.8"
   dependencies:
     "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.7.0
@@ -801,13 +801,25 @@ __metadata:
     react: ^18.2.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: 7adc5375987639c45dc06f973f4722c7dcba90585707d92d04ac8fcebeadd9b420d1d97970c081a612b0b100b23971b34014c9839a73ff39828961003717193d
+  checksum: 3ac006698c756a10e52e30961ba10095338660f8c5a8a9cfb3645495a03506193f5df66487f9741344e4d610bc1ebf0a918143876b66901a5933eb73b17c3bec
   languageName: node
   linkType: hard
 
-"@jupyter/docprovider@npm:^2.0.0, @jupyter/docprovider@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@jupyter/docprovider@npm:2.1.2"
+"@jupyter/collaborative-drive@npm:^3.0.0-beta.8":
+  version: 3.0.0-beta.8
+  resolution: "@jupyter/collaborative-drive@npm:3.0.0-beta.8"
+  dependencies:
+    "@jupyter/ydoc": ^2.0.0 || ^3.0.0-a3
+    "@jupyterlab/services": ^7.2.0
+    "@lumino/coreutils": ^2.1.0
+    "@lumino/disposable": ^2.1.0
+  checksum: a4ecf6778a6ff02e2ee6849ba7d8661cf83daf846fc8a01d7e7fb7bf5c0693cf345df8fc5bcd40d26714df7770e93674772c0ffdc620dfc94911f84c3cc6ddcb
+  languageName: node
+  linkType: hard
+
+"@jupyter/docprovider@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@jupyter/docprovider@npm:2.1.3"
   dependencies:
     "@jupyter/ydoc": ^1.1.0-a0
     "@jupyterlab/coreutils": ^6.0.5
@@ -818,7 +830,7 @@ __metadata:
     y-protocols: ^1.0.5
     y-websocket: ^1.3.15
     yjs: ^13.5.40
-  checksum: 51f049baa33f870e079518b7f0790ef5fb121f921763a0ba7caca34d3731e3bb98cbb03e2250746a8fd002c25d1f989353f09340cf7886cd08f745cdb4e3f4c4
+  checksum: e263f463eb4363b773d53ec47c50786143328321ab20c0c92f01f8a89349c8eec799063dbefb9b707c22d76c27e38e5f52f916881bb63c58ccc24d797a4e3f30
   languageName: node
   linkType: hard
 
@@ -859,9 +871,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^2.0.0, @jupyter/ydoc@npm:^2.0.1":
-  version: 2.1.1
-  resolution: "@jupyter/ydoc@npm:2.1.1"
+"@jupyter/ydoc@npm:^2.0.0 || ^3.0.0-a3":
+  version: 3.0.0-a9
+  resolution: "@jupyter/ydoc@npm:3.0.0-a9"
   dependencies:
     "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
     "@lumino/coreutils": ^1.11.0 || ^2.0.0
@@ -869,7 +881,21 @@ __metadata:
     "@lumino/signaling": ^1.10.0 || ^2.0.0
     y-protocols: ^1.0.5
     yjs: ^13.5.40
-  checksum: f10268d4d990f454279e3908a172755ed5885fa81bb70c31bdf66923598b283d26491741bece137d1c348619861e9b7f8354296773fe5352b1915e69101a9fb0
+  checksum: e821e2df4c5b9dd96cc4e283cad96be02ff5bcf45ae3d2d48605dc9083dc80de80b81158162438161fb4fe69f7062104b4e74dc07cf25af1f6e7f6af20727131
+  languageName: node
+  linkType: hard
+
+"@jupyter/ydoc@npm:^2.0.0, @jupyter/ydoc@npm:^2.0.1":
+  version: 2.1.2
+  resolution: "@jupyter/ydoc@npm:2.1.2"
+  dependencies:
+    "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
+    "@lumino/coreutils": ^1.11.0 || ^2.0.0
+    "@lumino/disposable": ^1.10.0 || ^2.0.0
+    "@lumino/signaling": ^1.10.0 || ^2.0.0
+    y-protocols: ^1.0.5
+    yjs: ^13.5.40
+  checksum: 4e4840120d5c93fffc62668c3867c25ef9d72f70c7cf2beefe2caaab47c4d3d08b1b2092806a9ae2a24852256584d3e2aa0b066295c2696147cd41e10f14e5b0
   languageName: node
   linkType: hard
 
@@ -893,7 +919,7 @@ __metadata:
   dependencies:
     "@apidevtools/json-schema-ref-parser": ^9.0.9
     "@deathbeds/jupyterlab-rjsf": ^1.1.0
-    "@jupyter/docprovider": ^2.0.0
+    "@jupyter/collaborative-drive": ^3.0.0-beta.8
     "@jupyter/ydoc": ^1.0.0
     "@jupytercad/occ-worker": ^3.0.0-alpha.3
     "@jupytercad/schema": ^3.0.0-alpha.3
@@ -936,8 +962,8 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.9.3
-    "@jupyter/collaboration": ^3.0.0-beta.6
-    "@jupyter/docprovider": ^2.0.0
+    "@jupyter/collaboration": ^3.0.0-beta.8
+    "@jupyter/collaborative-drive": ^3.0.0-beta.8
     "@jupyter/ydoc": ^0.3.4 || ^1.0.2
     "@jupytercad/base": ^3.0.0-alpha.3
     "@jupytercad/schema": ^3.0.0-alpha.3
@@ -1003,7 +1029,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupytercad/jupytercad-core@workspace:python/jupytercad_core"
   dependencies:
-    "@jupyter/docprovider": ^2.0.0
+    "@jupyter/collaborative-drive": ^3.0.0-beta.8
     "@jupytercad/base": ^3.0.0-alpha.3
     "@jupytercad/occ-worker": ^3.0.0-alpha.3
     "@jupytercad/schema": ^3.0.0-alpha.3
@@ -1038,7 +1064,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupytercad/jupytercad-lab@workspace:python/jupytercad_lab"
   dependencies:
-    "@jupyter/docprovider": ^2.0.0
+    "@jupyter/collaborative-drive": ^3.0.0-beta.8
     "@jupytercad/base": ^3.0.0-alpha.3
     "@jupytercad/jupytercad-core": ^3.0.0-alpha.3
     "@jupytercad/schema": ^3.0.0-alpha.3
@@ -4799,9 +4825,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001663":
-  version: 1.0.30001667
-  resolution: "caniuse-lite@npm:1.0.30001667"
-  checksum: f3c6a40c3e4115c6e5fb46c47884d903191285d29ec8a8b092546efbc9cdedcbd7183cce72dd3cab7dfc16c4d5b2745892876b3d6dda75d4cba49f9389239aa9
+  version: 1.0.30001668
+  resolution: "caniuse-lite@npm:1.0.30001668"
+  checksum: ce6996901b5883454a8ddb3040f82342277b6a6275876dfefcdecb11f7e472e29877f34cae47c2b674f08f2e71971dd4a2acb9bc01adfe8421b7148a7e9e8297
   languageName: node
   linkType: hard
 
@@ -5776,9 +5802,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.28":
-  version: 1.5.35
-  resolution: "electron-to-chromium@npm:1.5.35"
-  checksum: 7eca311ebce5ca5bbef7854becc7c84ea213edc8d0d02dedf998cd695e32e5bffb9803846a9a1801f29ce8f31d6b165c9d319e76923f93c2855fae80846f7610
+  version: 1.5.38
+  resolution: "electron-to-chromium@npm:1.5.38"
+  checksum: 8279317608f24f95366b679703c7e4196beb0702384fca211a5db4a53e6c960067d0f5de487883fe807b04eaba3939137a39958d6c5209b4d1e5a693efdd6f6a
   languageName: node
   linkType: hard
 
@@ -6592,13 +6618,13 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "form-data@npm:4.0.0"
+  version: 4.0.1
+  resolution: "form-data@npm:4.0.1"
   dependencies:
     asynckit: ^0.4.0
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
-  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
+  checksum: ccee458cd5baf234d6b57f349fe9cc5f9a2ea8fd1af5ecda501a18fd1572a6dd3bf08a49f00568afd995b6a65af34cb8dec083cf9d582c4e621836499498dd84
   languageName: node
   linkType: hard
 
@@ -8390,7 +8416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib0@npm:^0.2.31, lib0@npm:^0.2.42, lib0@npm:^0.2.52, lib0@npm:^0.2.76, lib0@npm:^0.2.85, lib0@npm:^0.2.86":
+"lib0@npm:^0.2.31, lib0@npm:^0.2.42, lib0@npm:^0.2.52, lib0@npm:^0.2.76, lib0@npm:^0.2.85, lib0@npm:^0.2.98":
   version: 0.2.98
   resolution: "lib0@npm:0.2.98"
   dependencies:
@@ -13201,11 +13227,11 @@ __metadata:
   linkType: hard
 
 "yjs@npm:^13.5.0, yjs@npm:^13.5.40":
-  version: 13.6.19
-  resolution: "yjs@npm:13.6.19"
+  version: 13.6.20
+  resolution: "yjs@npm:13.6.20"
   dependencies:
-    lib0: ^0.2.86
-  checksum: 1b6e1454128aa85d720dec41deab1a88f903e8a486532813dba1895752a3fbef468df0bd5549928d77eab232a25113501f794f7347e4e60e3b5efe8382f513a4
+    lib0: ^0.2.98
+  checksum: a87295efe7df58ae8b5cf09b7cdbbcc3cbfba2b7fb72bb424513eb25587eff8dc8304f41e3bcd3926c02c86a0f7ce2185285e4b9d71aca5ff50cefe1ecb6657c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,27 +762,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/collaboration@npm:^2.0.0":
-  version: 2.1.3
-  resolution: "@jupyter/collaboration@npm:2.1.3"
-  dependencies:
-    "@codemirror/state": ^6.2.0
-    "@codemirror/view": ^6.7.0
-    "@jupyter/docprovider": ^2.1.3
-    "@jupyterlab/apputils": ^4.0.5
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlab/services": ^7.0.5
-    "@jupyterlab/ui-components": ^4.0.5
-    "@lumino/coreutils": ^2.1.0
-    "@lumino/virtualdom": ^2.0.0
-    "@lumino/widgets": ^2.1.0
-    react: ^18.2.0
-    y-protocols: ^1.0.5
-    yjs: ^13.5.40
-  checksum: 7239bb4e0b3e30c32a07aecc073882a56392c6a848c086630db392a4876d8bcb2fc658ef444892b73f58e1126a899fa704e41ddea649b4665c422412024ec76a
-  languageName: node
-  linkType: hard
-
 "@jupyter/collaboration@npm:^3.0.0-beta.8":
   version: 3.0.0-beta.8
   resolution: "@jupyter/collaboration@npm:3.0.0-beta.8"
@@ -817,23 +796,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/docprovider@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@jupyter/docprovider@npm:2.1.3"
-  dependencies:
-    "@jupyter/ydoc": ^1.1.0-a0
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlab/services": ^7.0.5
-    "@lumino/coreutils": ^2.1.0
-    "@lumino/disposable": ^2.1.0
-    "@lumino/signaling": ^2.1.0
-    y-protocols: ^1.0.5
-    y-websocket: ^1.3.15
-    yjs: ^13.5.40
-  checksum: e263f463eb4363b773d53ec47c50786143328321ab20c0c92f01f8a89349c8eec799063dbefb9b707c22d76c27e38e5f52f916881bb63c58ccc24d797a4e3f30
-  languageName: node
-  linkType: hard
-
 "@jupyter/react-components@npm:^0.15.3":
   version: 0.15.3
   resolution: "@jupyter/react-components@npm:0.15.3"
@@ -857,21 +819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^0.3.4 || ^1.0.2, @jupyter/ydoc@npm:^1.0.0, @jupyter/ydoc@npm:^1.1.0-a0":
-  version: 1.1.1
-  resolution: "@jupyter/ydoc@npm:1.1.1"
-  dependencies:
-    "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
-    "@lumino/coreutils": ^1.11.0 || ^2.0.0
-    "@lumino/disposable": ^1.10.0 || ^2.0.0
-    "@lumino/signaling": ^1.10.0 || ^2.0.0
-    y-protocols: ^1.0.5
-    yjs: ^13.5.40
-  checksum: a239b1dd57cfc9ba36c06ac5032a1b6388849ae01a1d0db0d45094f71fdadf4d473b4bf8becbef0cfcdc85cae505361fbec0822b02da5aa48e06b66f742dd7a0
-  languageName: node
-  linkType: hard
-
-"@jupyter/ydoc@npm:^2.0.0 || ^3.0.0-a3":
+"@jupyter/ydoc@npm:^2.0.0 || ^3.0.0-a3, @jupyter/ydoc@npm:^3.0.0-a9":
   version: 3.0.0-a9
   resolution: "@jupyter/ydoc@npm:3.0.0-a9"
   dependencies:
@@ -920,7 +868,7 @@ __metadata:
     "@apidevtools/json-schema-ref-parser": ^9.0.9
     "@deathbeds/jupyterlab-rjsf": ^1.1.0
     "@jupyter/collaborative-drive": ^3.0.0-beta.8
-    "@jupyter/ydoc": ^1.0.0
+    "@jupyter/ydoc": ^3.0.0-a9
     "@jupytercad/occ-worker": ^3.0.0-alpha.3
     "@jupytercad/schema": ^3.0.0-alpha.3
     "@jupyterlab/application": ^4.0.0
@@ -964,7 +912,7 @@ __metadata:
     "@codemirror/view": ^6.9.3
     "@jupyter/collaboration": ^3.0.0-beta.8
     "@jupyter/collaborative-drive": ^3.0.0-beta.8
-    "@jupyter/ydoc": ^0.3.4 || ^1.0.2
+    "@jupyter/ydoc": ^3.0.0-a9
     "@jupytercad/base": ^3.0.0-alpha.3
     "@jupytercad/schema": ^3.0.0-alpha.3
     "@jupyterlab/application": ^4.0.0
@@ -1153,7 +1101,7 @@ __metadata:
   resolution: "@jupytercad/schema@workspace:packages/schema"
   dependencies:
     "@apidevtools/json-schema-ref-parser": ^9.0.9
-    "@jupyter/ydoc": ^1.0.0
+    "@jupyter/ydoc": ^3.0.0-a9
     "@jupyterlab/apputils": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/docregistry": ^4.0.0
@@ -2888,7 +2836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/signaling@npm:^1.10.0 || ^2.0.0, @lumino/signaling@npm:^1.10.0 || ^2.0.0-alpha.6, @lumino/signaling@npm:^2.0.0, @lumino/signaling@npm:^2.1.0, @lumino/signaling@npm:^2.1.1, @lumino/signaling@npm:^2.1.2, @lumino/signaling@npm:^2.1.3":
+"@lumino/signaling@npm:^1.10.0 || ^2.0.0, @lumino/signaling@npm:^1.10.0 || ^2.0.0-alpha.6, @lumino/signaling@npm:^2.0.0, @lumino/signaling@npm:^2.1.1, @lumino/signaling@npm:^2.1.2, @lumino/signaling@npm:^2.1.3":
   version: 2.1.3
   resolution: "@lumino/signaling@npm:2.1.3"
   dependencies:
@@ -4171,32 +4119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abstract-leveldown@npm:^6.2.1":
-  version: 6.3.0
-  resolution: "abstract-leveldown@npm:6.3.0"
-  dependencies:
-    buffer: ^5.5.0
-    immediate: ^3.2.3
-    level-concat-iterator: ~2.0.0
-    level-supports: ~1.0.0
-    xtend: ~4.0.0
-  checksum: 121a8509d8c6a540e656c2a69e5b8d853d4df71072011afefc868b98076991bb00120550e90643de9dc18889c675f62413409eeb4c8c204663124c7d215e4ec3
-  languageName: node
-  linkType: hard
-
-"abstract-leveldown@npm:~6.2.1, abstract-leveldown@npm:~6.2.3":
-  version: 6.2.3
-  resolution: "abstract-leveldown@npm:6.2.3"
-  dependencies:
-    buffer: ^5.5.0
-    immediate: ^3.2.3
-    level-concat-iterator: ~2.0.0
-    level-supports: ~1.0.0
-    xtend: ~4.0.0
-  checksum: 00202b2eb7955dd7bc04f3e44d225e60160cedb8f96fe6ae0e6dca9c356d57071f001ece8ae1d53f48095c4c036d92b3440f2bc7666730610ddea030f9fbde4a
-  languageName: node
-  linkType: hard
-
 "acorn-import-attributes@npm:^1.9.5":
   version: 1.9.5
   resolution: "acorn-import-attributes@npm:1.9.5"
@@ -4503,13 +4425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-limiter@npm:~1.0.0":
-  version: 1.0.1
-  resolution: "async-limiter@npm:1.0.1"
-  checksum: 2b849695b465d93ad44c116220dee29a5aeb63adac16c1088983c339b0de57d76e82533e8e364a93a9f997f28bbfc6a92948cefc120652bd07f3b59f8d75cf2b
-  languageName: node
-  linkType: hard
-
 "async@npm:^3.2.3":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
@@ -4654,7 +4569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.5.0, buffer@npm:^5.6.0":
+"buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -5595,16 +5510,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deferred-leveldown@npm:~5.3.0":
-  version: 5.3.0
-  resolution: "deferred-leveldown@npm:5.3.0"
-  dependencies:
-    abstract-leveldown: ~6.2.1
-    inherits: ^2.0.3
-  checksum: 5631e153528bb9de1aa60d59a5065d1a519374c5e4c1d486f2190dba4008dcf5c2ee8dd7f2f81396fc4d5a6bb6e7d0055e3dfe68afe00da02adaa3bf329addf7
-  languageName: node
-  linkType: hard
-
 "define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
   version: 1.1.4
   resolution: "define-data-property@npm:1.1.4"
@@ -5829,18 +5734,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encoding-down@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "encoding-down@npm:6.3.0"
-  dependencies:
-    abstract-leveldown: ^6.2.1
-    inherits: ^2.0.3
-    level-codec: ^9.0.0
-    level-errors: ^2.0.0
-  checksum: 74043e6d9061a470614ff61d708c849259ab32932a428fd5ddfb0878719804f56a52f59b31cccd95fddc2e636c0fd22dc3e02481fb98d5bf1bdbbbc44ca09bdc
-  languageName: node
-  linkType: hard
-
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -5914,17 +5807,6 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: 8b7b1be20d2de12d2255c0bc2ca638b7af5171142693299416e6a9339bd7d88fc8d7707d913d78e0993176005405a236b066b45666b27b797252c771156ace54
-  languageName: node
-  linkType: hard
-
-"errno@npm:~0.1.1":
-  version: 0.1.8
-  resolution: "errno@npm:0.1.8"
-  dependencies:
-    prr: ~1.0.1
-  bin:
-    errno: cli.js
-  checksum: 1271f7b9fbb3bcbec76ffde932485d1e3561856d21d847ec613a9722ee924cdd4e523a62dc71a44174d91e898fe21fdc8d5b50823f4b5e0ce8c35c8271e6ef4a
   languageName: node
   linkType: hard
 
@@ -6439,9 +6321,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "fast-uri@npm:3.0.2"
-  checksum: ca00aadc84e0ab93a8a1700c386bc7cbeb49f47d9801083c258444eed31221fdf864d68fb48ea8acd7c512bf046b53c09e3aafd6d4bdb9449ed21be29d8d6f75
+  version: 3.0.3
+  resolution: "fast-uri@npm:3.0.3"
+  checksum: c52e6c86465f5c240e84a4485fb001088cc743d261a4b54b0050ce4758b1648bdbe53da1328ef9620149dca1435e3de64184f226d7c0a3656cb5837b3491e149
   languageName: node
   linkType: hard
 
@@ -7383,13 +7265,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immediate@npm:^3.2.3":
-  version: 3.3.0
-  resolution: "immediate@npm:3.3.0"
-  checksum: 634b4305101e2452eba6c07d485bf3e415995e533c94b9c3ffbc37026fa1be34def6e4f2276b0dc2162a3f91628564a4bfb26280278b89d3ee54624e854d2f5f
-  languageName: node
-  linkType: hard
-
 "import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -8303,109 +8178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"level-codec@npm:^9.0.0":
-  version: 9.0.2
-  resolution: "level-codec@npm:9.0.2"
-  dependencies:
-    buffer: ^5.6.0
-  checksum: 289003d51b8afcdd24c4d318606abf2bae81975e4b527d7349abfdbacc8fef26711f2f24e2d20da0e1dce0bb216a856c9433ccb9ca25fa78a96aed9f51e506ed
-  languageName: node
-  linkType: hard
-
-"level-concat-iterator@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "level-concat-iterator@npm:2.0.1"
-  checksum: 562583ef1292215f8e749c402510cb61c4d6fccf4541082b3d21dfa5ecde9fcccfe52bdcb5cfff9d2384e7ce5891f44df9439a6ddb39b0ffe31015600b4a828a
-  languageName: node
-  linkType: hard
-
-"level-errors@npm:^2.0.0, level-errors@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "level-errors@npm:2.0.1"
-  dependencies:
-    errno: ~0.1.1
-  checksum: aca5d7670e2a40609db8d7743fce289bb5202c0bc13e4a78f81f36a6642e9abc0110f48087d3d3c2c04f023d70d4ee6f2db0e20c63d29b3fda323a67bfff6526
-  languageName: node
-  linkType: hard
-
-"level-iterator-stream@npm:~4.0.0":
-  version: 4.0.2
-  resolution: "level-iterator-stream@npm:4.0.2"
-  dependencies:
-    inherits: ^2.0.4
-    readable-stream: ^3.4.0
-    xtend: ^4.0.2
-  checksum: 239e2c7e62bffb485ed696bcd3b98de7a2bc455d13be4fce175ae3544fe9cda81c2ed93d3e88b61380ae6d28cce02511862d77b86fb2ba5b5cf00471f3c1eccc
-  languageName: node
-  linkType: hard
-
-"level-js@npm:^5.0.0":
-  version: 5.0.2
-  resolution: "level-js@npm:5.0.2"
-  dependencies:
-    abstract-leveldown: ~6.2.3
-    buffer: ^5.5.0
-    inherits: ^2.0.3
-    ltgt: ^2.1.2
-  checksum: 3c7f75979bb8c042e95a58245b8fe1230bb0f56a11ee418e08156e3eadda371efae6eb7b9bf10bf1e08e0b1b2a25d80c026858ca99ffd49109d6541e3d9d3b37
-  languageName: node
-  linkType: hard
-
-"level-packager@npm:^5.1.0":
-  version: 5.1.1
-  resolution: "level-packager@npm:5.1.1"
-  dependencies:
-    encoding-down: ^6.3.0
-    levelup: ^4.3.2
-  checksum: befe2aa54f2010a6ecf7ddce392c8dee225e1839205080a2704d75e560e28b01191b345494696196777b70d376e3eaae4c9e7c330cc70d3000839f5b18dd78f2
-  languageName: node
-  linkType: hard
-
-"level-supports@npm:~1.0.0":
-  version: 1.0.1
-  resolution: "level-supports@npm:1.0.1"
-  dependencies:
-    xtend: ^4.0.2
-  checksum: 5d6bdb88cf00c3d9adcde970db06a548c72c5a94bf42c72f998b58341a105bfe2ea30d313ce1e84396b98cc9ddbc0a9bd94574955a86e929f73c986e10fc0df0
-  languageName: node
-  linkType: hard
-
-"level@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "level@npm:6.0.1"
-  dependencies:
-    level-js: ^5.0.0
-    level-packager: ^5.1.0
-    leveldown: ^5.4.0
-  checksum: bd4981f94162469a82a6c98d267d814d9d4a7beed4fc3d18fbe3b156f71cf4c6d35b424d14c46d401dbf0cd91425e842950a7cd17ddf7bf57acdab5af4c278da
-  languageName: node
-  linkType: hard
-
-"leveldown@npm:^5.4.0":
-  version: 5.6.0
-  resolution: "leveldown@npm:5.6.0"
-  dependencies:
-    abstract-leveldown: ~6.2.1
-    napi-macros: ~2.0.0
-    node-gyp: latest
-    node-gyp-build: ~4.1.0
-  checksum: 06d4683170d7fc661acd65457e531b42ad66480e9339d3154ba6d0de38ff0503d7d017c1c6eba12732b5488ecd2915c70c8dc3a7d67f4a836f3de34b8a993949
-  languageName: node
-  linkType: hard
-
-"levelup@npm:^4.3.2":
-  version: 4.4.0
-  resolution: "levelup@npm:4.4.0"
-  dependencies:
-    deferred-leveldown: ~5.3.0
-    level-errors: ~2.0.0
-    level-iterator-stream: ~4.0.0
-    level-supports: ~1.0.0
-    xtend: ~4.0.0
-  checksum: 5a09e34c78cd7c23f9f6cb73563f1ebe8121ffc5f9f5f232242529d4fbdd40e8d1ffb337d2defa0b842334e0dbd4028fbfe7a072eebfe2c4d07174f0aa4aabca
-  languageName: node
-  linkType: hard
-
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -8416,7 +8188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib0@npm:^0.2.31, lib0@npm:^0.2.42, lib0@npm:^0.2.52, lib0@npm:^0.2.76, lib0@npm:^0.2.85, lib0@npm:^0.2.98":
+"lib0@npm:^0.2.42, lib0@npm:^0.2.76, lib0@npm:^0.2.85, lib0@npm:^0.2.98":
   version: 0.2.98
   resolution: "lib0@npm:0.2.98"
   dependencies:
@@ -8559,13 +8331,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.debounce@npm:^4.0.8":
-  version: 4.0.8
-  resolution: "lodash.debounce@npm:4.0.8"
-  checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
-  languageName: node
-  linkType: hard
-
 "lodash.escape@npm:^4.0.1":
   version: 4.0.1
   resolution: "lodash.escape@npm:4.0.1"
@@ -8658,13 +8423,6 @@ __metadata:
   dependencies:
     es5-ext: ~0.10.2
   checksum: 7f2c53c5e7f2de20efb6ebb3086b7aea88d6cf9ae91ac5618ece974122960c4e8ed04988e81d92c3e63d60b12c556b14d56ef7a9c5a4627b23859b813e39b1a2
-  languageName: node
-  linkType: hard
-
-"ltgt@npm:^2.1.2":
-  version: 2.2.1
-  resolution: "ltgt@npm:2.2.1"
-  checksum: 7e3874296f7538bc8087b428ac4208008d7b76916354b34a08818ca7c83958c1df10ec427eeeaad895f6b81e41e24745b18d30f89abcc21d228b94f6961d50a2
   languageName: node
   linkType: hard
 
@@ -9225,13 +8983,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"napi-macros@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "napi-macros@npm:2.0.0"
-  checksum: 30384819386977c1f82034757014163fa60ab3c5a538094f778d38788bebb52534966279956f796a92ea771c7f8ae072b975df65de910d051ffbdc927f62320c
-  languageName: node
-  linkType: hard
-
 "natural-compare-lite@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare-lite@npm:1.4.0"
@@ -9326,17 +9077,6 @@ __metadata:
     node-gyp-build-optional: optional.js
     node-gyp-build-test: build-test.js
   checksum: 1a57bba8c4c193f808bd8ad1484d4ebdd8106dd9f04a3e82554dc716e3a2d87d7e369e9503c145e0e6a7e2c663fec0d8aaf52bd8156342ec7fc388195f37824e
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:~4.1.0":
-  version: 4.1.1
-  resolution: "node-gyp-build@npm:4.1.1"
-  bin:
-    node-gyp-build: ./bin.js
-    node-gyp-build-optional: ./optional.js
-    node-gyp-build-test: ./build-test.js
-  checksum: 959d42221cc44b92700003efae741652bc4e379e4cf375830ddde03ba43c89f99694bf0883078ed0d4e03ffe2f85decab0572e04068d3900b8538d165dbc17df
   languageName: node
   linkType: hard
 
@@ -10419,13 +10159,6 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
-  languageName: node
-  linkType: hard
-
-"prr@npm:~1.0.1":
-  version: 1.0.1
-  resolution: "prr@npm:1.0.1"
-  checksum: 3bca2db0479fd38f8c4c9439139b0c42dcaadcc2fbb7bb8e0e6afaa1383457f1d19aea9e5f961d5b080f1cfc05bfa1fe9e45c97a1d3fd6d421950a73d3108381
   languageName: node
   linkType: hard
 
@@ -12176,9 +11909,9 @@ __metadata:
   linkType: hard
 
 "tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
-  version: 2.7.0
-  resolution: "tslib@npm:2.7.0"
-  checksum: 1606d5c89f88d466889def78653f3aab0f88692e80bb2066d090ca6112ae250ec1cfa9dbfaab0d17b60da15a4186e8ec4d893801c67896b277c17374e36e1d28
+  version: 2.8.0
+  resolution: "tslib@npm:2.8.0"
+  checksum: de852ecd81adfdb4870927e250763345f07dc13fe7f395ce261424966bb122a0992ad844c3ec875c9e63e72afe2220a150712984e44dfd1a8a7e538a064e3d46
   languageName: node
   linkType: hard
 
@@ -13049,15 +12782,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^6.2.1":
-  version: 6.2.3
-  resolution: "ws@npm:6.2.3"
-  dependencies:
-    async-limiter: ~1.0.0
-  checksum: bbc96ff5628832d80669a88fd117487bf070492dfaa50df77fa442a2b119792e772f4365521e0a8e025c0d51173c54fa91adab165c11b8e0674685fdd36844a5
-  languageName: node
-  linkType: hard
-
 "ws@npm:^8.11.0":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
@@ -13073,7 +12797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.2, xtend@npm:~4.0.0, xtend@npm:~4.0.1":
+"xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
@@ -13092,18 +12816,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y-leveldb@npm:^0.1.0":
-  version: 0.1.2
-  resolution: "y-leveldb@npm:0.1.2"
-  dependencies:
-    level: ^6.0.1
-    lib0: ^0.2.31
-  peerDependencies:
-    yjs: ^13.0.0
-  checksum: 38e3293cfc5e754ba50af4c6bd03a96efde34c92809baf504b38cb4f45959187f896fe6971fa6a91823763e178807aaa14e190d1f7bea1b3a1e9b7265bb88b6d
-  languageName: node
-  linkType: hard
-
 "y-protocols@npm:^1.0.5":
   version: 1.0.6
   resolution: "y-protocols@npm:1.0.6"
@@ -13112,29 +12824,6 @@ __metadata:
   peerDependencies:
     yjs: ^13.0.0
   checksum: 4b57c8811befcf2e45c3d47830005f8a33e626c734f78a42fe8a4fa3caad2233ba85a7c8bceefbd52ffc40130d3f3faee664fd0d1c324ff1fa8817a056ccdc1c
-  languageName: node
-  linkType: hard
-
-"y-websocket@npm:^1.3.15":
-  version: 1.5.4
-  resolution: "y-websocket@npm:1.5.4"
-  dependencies:
-    lib0: ^0.2.52
-    lodash.debounce: ^4.0.8
-    ws: ^6.2.1
-    y-leveldb: ^0.1.0
-    y-protocols: ^1.0.5
-  peerDependencies:
-    yjs: ^13.5.6
-  dependenciesMeta:
-    ws:
-      optional: true
-    y-leveldb:
-      optional: true
-  bin:
-    y-websocket: bin/server.js
-    y-websocket-server: bin/server.js
-  checksum: 4ab3f99cf5f3b2bb3dd12603bc85e7fc338c64636b0d2b654af16662b5600bdfa6fcaaeb4258e02b9a0dc7d90441728dc07874cf5f7eeeb837c27df53e72670f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #471.

[yjs-widgets](https://github.com/QuantStack/yjs-widgets) will also have to use jupyter-collaboration v3.