### PR TITLE
Exaggerate clip plane size

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -747,8 +747,8 @@ export class MainView extends React.Component<IProps, IStates> {
 
     // Clip plane rendering
     const planeGeom = new THREE.PlaneGeometry(
-      this._refLength! * 10, // *10 is a bit arbitrary and extreme but that does not impact performance or anything
-      this._refLength! * 10
+      this._refLength! * 1000, // *1000 is a bit arbitrary and extreme but that does not impact performance or anything
+      this._refLength! * 1000
     );
     const planeMat = new THREE.MeshPhongMaterial({
       color: DEFAULT_EDGE_COLOR,


### PR DESCRIPTION
The clipplane mesh is not fully filling the gap left by the clipping effect. This PR fixes it.

Before:

https://github.com/user-attachments/assets/b59b2d6e-d6bc-476c-b3a0-195e2bcf23f7

After:

https://github.com/user-attachments/assets/787da56a-b826-450c-8bdb-8854ac895824

