### PR TITLE
Fix context switching for the right panel

### DIFF
--- a/packages/base/src/panelview/objectproperties.tsx
+++ b/packages/base/src/panelview/objectproperties.tsx
@@ -83,7 +83,10 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
           this._onClientSharedStateChanged
         );
         this.setState(old => ({
-          ...old,
+          jcadOption: undefined,
+          selectedObjectData: undefined,
+          selectedObject: undefined,
+          schema: undefined,
           filePath: changed.context.localPath,
           jcadObject: this.props.cpModel.jcadModel?.getAllObject(),
           clientId: changed.context.model.getClientId()


### PR DESCRIPTION
This fixes the issue we're seeing when coming from a "STL" file context to a "JCAD" context:

[Screencast from 2024-10-24 17-27-36.webm](https://github.com/user-attachments/assets/43179fb7-4c11-4f42-a239-1c6474f35db9)
