### PR TITLE
Set visible back to True for operator inputs upon removal of the output

### DIFF
--- a/packages/base/src/panelview/objecttree.tsx
+++ b/packages/base/src/panelview/objecttree.tsx
@@ -137,7 +137,7 @@ export const handleRemoveObject = (
           setVisible(sharedModel, dependency, true);
         });
         sharedModel.removeObjects(toRemove);
-      })
+      });
     }
   });
 

--- a/packages/base/src/panelview/objecttree.tsx
+++ b/packages/base/src/panelview/objecttree.tsx
@@ -29,6 +29,7 @@ import { v4 as uuid } from 'uuid';
 import visibilitySvg from '../../style/icon/visibility.svg';
 import visibilityOffSvg from '../../style/icon/visibilityOff.svg';
 import { IControlPanelModel } from '../types';
+import { setVisible } from '../commands';
 
 const visibilityIcon = new LabIcon({
   name: 'jupytercad:visibilityIcon',
@@ -98,7 +99,7 @@ interface IProps {
 
 export const handleRemoveObject = (
   objectId: string,
-  sharedModel: any,
+  sharedModel: IJupyterCadDoc,
   syncSelected: () => void
 ): void => {
   if (!sharedModel) {
@@ -130,7 +131,13 @@ export const handleRemoveObject = (
   }).then(({ button: { accept } }) => {
     if (accept) {
       const toRemove = dependants.concat([objectId]);
-      sharedModel.removeObjects(toRemove);
+      const objetToRemove = sharedModel.getObjectByName(objectId);
+      sharedModel.transact(() => {
+        objetToRemove?.dependencies?.forEach((dependency: string) => {
+          setVisible(sharedModel, dependency, true);
+        });
+        sharedModel.removeObjects(toRemove);
+      })
     }
   });
 


### PR DESCRIPTION
Fix https://github.com/jupytercad/JupyterCAD/issues/426


https://github.com/user-attachments/assets/7ff7dddd-0537-4d3f-994a-544d8dc5da71


