### PR TITLE
Revert "Orthographic camera: fix missing near and far parameters"

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1391,9 +1391,7 @@ export class MainView extends React.Component<IProps, IStates> {
         width / -2,
         width / 2,
         height / 2,
-        height / -2,
-        CAMERA_NEAR,
-        CAMERA_FAR
+        height / -2
       );
       this._camera.zoom = zoomFactor;
       this._camera.updateProjectionMatrix();


### PR DESCRIPTION
Reverts jupytercad/JupyterCAD#510

Setting such a big difference between near and far brings issues with close objects and the orthographic camera does not use the logarithmic buffer IIUC. Let's just revert it for now. We won't have something working for big and small objects but we should fix it differently