### PR TITLE
Fix typo in comment-on-pr.yml

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: 'Comment galata link on workflow'
         uses: trungleduc/appsharingspace-pr-comment/.github/actions/pr-comment@v2
         with:
-          comment_prefix: '**Integration tests repot:**'
+          comment_prefix: '**Integration tests report:**'
           artifact_name: galata-apss
           github_token: ${{ secrets.github_token }}
           index_path: playwright-report/index.html


### PR DESCRIPTION
I saw your comment on the GHA static hosting discussion and noticed this typo when browsing your code