### PR TITLE
Bug fix: Prevent tree from wrongly updating the selection

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -240,13 +240,11 @@ export async function executeOperator(
   }
   sharedModel.transact(() => {
     transaction(sharedModel);
-  });
-  setTimeout(() => {
     current.context.model.syncSelected(
       { [objectModel.name]: { type: 'shape' } },
       uuid()
     );
-  }, 0); // doing the selection at the next tick
+  });
 }
 
 const OPERATORS = {
@@ -1248,12 +1246,10 @@ namespace Private {
                 objectModel.shapeMetadata = objMeta;
               }
               sharedModel.addObject(objectModel);
-              setTimeout(() => {
-                jcadModel.syncSelected(
-                  { [objectModel.name]: { type: 'shape' } },
-                  uuid()
-                );
-              }, 0); // doing the selection at the next tick
+              jcadModel.syncSelected(
+                { [objectModel.name]: { type: 'shape' } },
+                uuid()
+              );
             } else {
               showErrorMessage(
                 'The object already exists',


### PR DESCRIPTION
Fix #560 

Fix:
- The tree was setting the wrong selection
- The tree was updating the selection and re-rendering itself **for each mouse move** in the 3D view

This PR should prevent jumping selection and improve performance, hopefully.