### PR TITLE
Add a min-height to the toolbar separator

### DIFF
--- a/python/jupytercad_lab/style/base.css
+++ b/python/jupytercad_lab/style/base.css
@@ -211,6 +211,7 @@ div.jpcad-toolbar-widget > div.jp-Toolbar-item:last-child {
 }
 
 .jcad-Toolbar-Separator {
+  min-height: 25px;
   width: var(--jp-border-width);
   background-color: var(--jp-border-color1);
   padding-left: 0px !important;


### PR DESCRIPTION
This PR fix the toolbar separator not displayed in the popup toolbar.

Related to https://github.com/jupyterlab/jupyterlab/issues/16884

![image](https://github.com/user-attachments/assets/5c215e57-90cc-4345-ac67-81c739123342)
