### PR TITLE
Do not show the transform if there is no current selection

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1524,7 +1524,9 @@ export class MainView extends React.Component<IProps, IStates> {
         this.setState(
           old => ({ ...old, transform: transformEnabled }),
           () => {
-            this._updateTransformControls(Object.keys(this._currentSelection || {}));
+            this._updateTransformControls(
+              Object.keys(this._currentSelection || {})
+            );
           }
         );
       }

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1524,8 +1524,7 @@ export class MainView extends React.Component<IProps, IStates> {
         this.setState(
           old => ({ ...old, transform: transformEnabled }),
           () => {
-            this._transformControls.visible = transformEnabled;
-            this._transformControls.enabled = transformEnabled;
+            this._updateTransformControls(Object.keys(this._currentSelection || {}));
           }
         );
       }


### PR DESCRIPTION
Fix https://github.com/jupytercad/JupyterCAD/issues/611 and also happens to fix https://github.com/jupytercad/JupyterCAD/issues/596 (it does not show anymore the transform controls upon toggle if an edge is selected)