### PR TITLE
No transform controls when exploded view is enabled

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1240,7 +1240,7 @@ export class MainView extends React.Component<IProps, IStates> {
    * Attach the transform controls to the current selection, or detach it
    */
   private _updateTransformControls(selection: string[]) {
-    if (selection.length === 1) {
+    if (selection.length === 1 && !this._explodedView.enabled) {
       const selectedMeshName = selection[0];
       const matchingChild = this._meshGroup?.children.find(child =>
         child.name.startsWith(selectedMeshName)
@@ -1595,6 +1595,8 @@ export class MainView extends React.Component<IProps, IStates> {
 
       this._explodedViewLinesHelperGroup?.removeFromParent();
     }
+
+    this._updateTransformControls(Object.keys(this._currentSelection || {}));
   }
 
   private _updateCamera() {

--- a/packages/base/src/3dview/mainviewmodel.ts
+++ b/packages/base/src/3dview/mainviewmodel.ts
@@ -18,7 +18,12 @@ import {
 } from '@jupytercad/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { ObservableMap } from '@jupyterlab/observables';
-import { JSONObject, JSONValue, PromiseDelegate, UUID } from '@lumino/coreutils';
+import {
+  JSONObject,
+  JSONValue,
+  PromiseDelegate,
+  UUID
+} from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
 import { v4 as uuid } from 'uuid';

--- a/packages/base/src/3dview/mainviewmodel.ts
+++ b/packages/base/src/3dview/mainviewmodel.ts
@@ -18,7 +18,7 @@ import {
 } from '@jupytercad/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { ObservableMap } from '@jupyterlab/observables';
-import { JSONValue, PromiseDelegate, UUID } from '@lumino/coreutils';
+import { JSONObject, JSONValue, PromiseDelegate, UUID } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { ISignal, Signal } from '@lumino/signaling';
 import { v4 as uuid } from 'uuid';
@@ -51,12 +51,21 @@ export class MainViewModel implements IDisposable {
   get workerBusy(): ISignal<this, boolean> {
     return this._workerBusy;
   }
+
   get jcadModel() {
     return this._jcadModel;
   }
 
   get viewSettingChanged() {
     return this._viewSetting.changed;
+  }
+
+  get viewSettings(): JSONObject {
+    const settings: JSONObject = {};
+    for (const key of this._viewSetting.keys()) {
+      settings[key] = this._viewSetting.get(key) || null;
+    }
+    return settings;
   }
 
   dispose(): void {

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -962,12 +962,18 @@ export function addCommands(
     isEnabled: () => {
       const current = tracker.currentWidget;
 
-      if (!current || !tracker.currentWidget.context.model.sharedModel.editable) {
+      if (
+        !current ||
+        !tracker.currentWidget.context.model.sharedModel.editable
+      ) {
         return false;
       }
 
-      const viewSettings = tracker.currentWidget.content.currentViewModel.viewSettings as JSONObject;
-      return viewSettings.explodedView ? !(viewSettings.explodedView as ExplodedView).enabled : true;
+      const viewSettings = tracker.currentWidget.content.currentViewModel
+        .viewSettings as JSONObject;
+      return viewSettings.explodedView
+        ? !(viewSettings.explodedView as ExplodedView).enabled
+        : true;
     },
     isToggled: () => {
       const current = tracker.currentWidget?.content;
@@ -1040,8 +1046,11 @@ export function addCommands(
     isEnabled: () => Boolean(tracker.currentWidget),
     icon: explodedViewIcon,
     isToggled: () => {
-      const viewSettings = tracker.currentWidget?.content.currentViewModel.viewSettings as JSONObject;
-      return viewSettings?.explodedView ? (viewSettings.explodedView as ExplodedView).enabled : false;
+      const viewSettings = tracker.currentWidget?.content.currentViewModel
+        .viewSettings as JSONObject;
+      return viewSettings?.explodedView
+        ? (viewSettings.explodedView as ExplodedView).enabled
+        : false;
     },
     execute: async () => {
       const current = tracker.currentWidget;

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -45,6 +45,8 @@ import { PathExt } from '@jupyterlab/coreutils';
 import { MainViewModel } from './3dview/mainviewmodel';
 import { handleRemoveObject } from './panelview';
 import { v4 as uuid } from 'uuid';
+import { ExplodedView } from './types';
+import { JSONObject } from '@lumino/coreutils';
 export function newName(type: string, model: IJupyterCadModel): string {
   const sharedModel = model.sharedModel;
 
@@ -958,9 +960,14 @@ export function addCommands(
   commands.addCommand(CommandIDs.transform, {
     label: trans.__('Toggle Transform Controls'),
     isEnabled: () => {
-      return tracker.currentWidget
-        ? tracker.currentWidget.context.model.sharedModel.editable
-        : false;
+      const current = tracker.currentWidget;
+
+      if (!current || !tracker.currentWidget.context.model.sharedModel.editable) {
+        return false;
+      }
+
+      const viewSettings = tracker.currentWidget.content.currentViewModel.viewSettings as JSONObject;
+      return viewSettings.explodedView ? !(viewSettings.explodedView as ExplodedView).enabled : true;
     },
     isToggled: () => {
       const current = tracker.currentWidget?.content;
@@ -1032,6 +1039,10 @@ export function addCommands(
     label: trans.__('Exploded View'),
     isEnabled: () => Boolean(tracker.currentWidget),
     icon: explodedViewIcon,
+    isToggled: () => {
+      const viewSettings = tracker.currentWidget?.content.currentViewModel.viewSettings as JSONObject;
+      return viewSettings?.explodedView ? (viewSettings.explodedView as ExplodedView).enabled : false;
+    },
     execute: async () => {
       const current = tracker.currentWidget;
 
@@ -1048,6 +1059,11 @@ export function addCommands(
         cancelButton: true
       });
       await dialog.launch();
+
+      commands.notifyCommandChanged(CommandIDs.updateExplodedView);
+
+      // Notify change so that toggle button for transform disables if needed
+      commands.notifyCommandChanged(CommandIDs.transform);
     }
   });
 


### PR DESCRIPTION
Fix https://github.com/jupytercad/JupyterCAD/issues/599

Also make the exploded view button a toggle button for the fun of it

https://github.com/user-attachments/assets/b7b6fddb-947b-475b-ac25-0d403e52e028

