### PR TITLE
Fix empty README issue on PyPi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,8 +201,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
-        with:
-          ignore_glob: README.md
 
   build-lite:
     name: Build JupyterLite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version"]
 path = "python/jupytercad/jupytercad/__init__.py"
 
 [tool.jupyter-releaser]
-skip = [ "check-python", "check-links" ]
+skip = [ "check-python" ]
 
 
 [tool.jupyter-releaser.options]

--- a/python/jupytercad/README.md
+++ b/python/jupytercad/README.md
@@ -6,7 +6,7 @@ JupyterCAD is a JupyterLab extension for 3D geometry modeling with collaborative
 
 JupyterCAD has support for FreeCAD files, which makes it easy to import and export models from FreeCAD. It also has a range of features for creating and manipulating 3D shapes, including a variety of primitives, transformations, and Boolean operations.
 
-![jupytercad](../../docs/source/assets/jupytercad-screenshot.png)
+![jupytercad](https://raw.githubusercontent.com/jupytercad/JupyterCAD/refs/heads/main/docs/source/assets/jupytercad-screenshot.png)
 
 ## Requirements
 
@@ -39,7 +39,7 @@ Check out the JupyterCAD documentation on ReadTheDocs! https://jupytercad.readth
 
 JupyterCAD is an open-source project, and contributions are always welcome. If you would like to contribute to JupyterCAD, please fork the repository and submit a pull request.
 
-See [CONTRIBUTING](../../CONTRIBUTING.md) for dev installation instructions.
+See [CONTRIBUTING](https://github.com/jupytercad/JupyterCAD/blob/main/CONTRIBUTING.md) for dev installation instructions.
 
 ## License
 


### PR DESCRIPTION
The description on PyPi is empty: https://pypi.org/project/jupytercad/#description

This is easily fixable by making a symlink of the README