### PR TITLE
Fix breaking change introduced in 3.1.0

### DIFF
--- a/python/jupytercad_core/src/factory.ts
+++ b/python/jupytercad_core/src/factory.ts
@@ -85,3 +85,6 @@ export class JupyterCadDocumentWidgetFactory extends ABCWidgetFactory<
   private _externalCommandRegistry: IJCadExternalCommandRegistry;
   private _backendCheck?: () => boolean;
 }
+
+// Backward compat
+export const JupyterCadWidgetFactory = JupyterCadDocumentWidgetFactory;


### PR DESCRIPTION
We introduced class renames in 3.1.0. This PR brings one back.