### PR TITLE
Fix ArchDetail.jcad annotations model + check exploded view

### DIFF
--- a/examples/ArchDetail.jcad
+++ b/examples/ArchDetail.jcad
@@ -1,7 +1,6 @@
 {
   "metadata": {
-    "annotation_29c5280e-8625-4df2-912a-32aa90017552": "{\"position\":[-36.1767807258494,99.75043783365507,538.2064137258739],\"label\":\"New annotation\",\"contents\":[{\"value\":\"I don't like this window color, can you change it?\",\"user\":{\"username\":\"df6d8fe262c641fcafa07da7336acbad\",\"name\":\"Anonymous Erinome\",\"display_name\":\"Anonymous Erinome\",\"initials\":\"AE\",\"avatar_url\":null,\"color\":\"var(--jp-collaborator-color7)\"}}]}",
-    "annotation_6f237b7c-d600-4d8d-a357-ad475c94ad93": "{\"position\":[-152.5901027396778,40.161167083635746,352],\"label\":\"New annotation\",\"contents\":[{\"value\":\"This floor is not wide enough\",\"user\":{\"username\":\"df6d8fe262c641fcafa07da7336acbad\",\"name\":\"Anonymous Erinome\",\"display_name\":\"Anonymous Erinome\",\"initials\":\"AE\",\"avatar_url\":null,\"color\":\"var(--jp-collaborator-color7)\"}}]}"
+    "annotation_1a8070b9-1daa-49e1-a848-fd5b454bdae4": "{\"position\":[-130.26230074366637,30.671260581525274,0],\"label\":\"New annotation\",\"contents\":[{\"value\":\"The floor should be thicker\",\"user\":{\"username\":\"c5a9d7c1fc1441e5946c60296e623b1b\",\"name\":\"Anonymous Callirrhoe\",\"display_name\":\"Anonymous Callirrhoe\",\"initials\":\"AC\",\"avatar_url\":null,\"color\":\"var(--jp-collaborator-color7)\"}}],\"parent\":\"Structure014\"}"
   },
   "objects": [
     {

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -213,7 +213,7 @@ export class MainView extends React.Component<IProps, IStates> {
         );
 
         // If in exploded view, we scale down to the initial position (to before exploding the view)
-        if (this._explodedView.enabled) {
+        if (this.explodedViewEnabled) {
           const explodedState = computeExplodedState({
             mesh: this._pointer3D.mesh,
             boundingGroup: this._boundingGroup,
@@ -714,7 +714,7 @@ export class MainView extends React.Component<IProps, IStates> {
       this._pointer3D.parent = picked.mesh;
 
       // If in exploded view, we scale down to the initial position (to before exploding the view)
-      if (this._explodedView.enabled) {
+      if (this.explodedViewEnabled) {
         const explodedState = computeExplodedState({
           mesh: this._pointer3D.parent,
           boundingGroup: this._boundingGroup,
@@ -1440,7 +1440,7 @@ export class MainView extends React.Component<IProps, IStates> {
         collaboratorPointer.mesh.visible = true;
 
         // If we are in exploded view, we display the collaborator cursor at the exploded position
-        if (this._explodedView.enabled) {
+        if (this.explodedViewEnabled) {
           const explodedState = computeExplodedState({
             mesh: parent,
             boundingGroup: this._boundingGroup,
@@ -1611,8 +1611,12 @@ export class MainView extends React.Component<IProps, IStates> {
     }
   }
 
+  get explodedViewEnabled(): boolean {
+    return this._explodedView.enabled && this._explodedView.factor !== 0;
+  }
+
   private _setupExplodedView() {
-    if (this._explodedView.enabled) {
+    if (this.explodedViewEnabled) {
       const center = new THREE.Vector3();
       this._boundingGroup.getCenter(center);
 
@@ -1870,7 +1874,7 @@ export class MainView extends React.Component<IProps, IStates> {
     );
 
     // If in exploded view, we explode the annotation position as well
-    if (this._explodedView.enabled && parent) {
+    if (this.explodedViewEnabled && parent) {
       const explodedState = computeExplodedState({
         mesh: parent,
         boundingGroup: this._boundingGroup,


### PR DESCRIPTION
- Fix ArchDetail.jcad annotations model
- Fix check for factor === 0, which was preventing to create an annotation when enabled=true and factor=0