### PR TITLE
Replace the FormDialog by a toggle button for the axes helper

### DIFF
--- a/packages/base/src/3dview/helpers.ts
+++ b/packages/base/src/3dview/helpers.ts
@@ -353,6 +353,7 @@ export function buildShape(options: {
   );
   boundingBox.position.copy(center);
   boundingBox.visible = false;
+  boundingBox.renderOrder = 1;
   boundingBox.name = SELECTION_BOUNDING_BOX;
   meshGroup.add(boundingBox);
 

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1182,10 +1182,10 @@ export class MainView extends React.Component<IProps, IStates> {
     const material = new THREE.MeshBasicMaterial({
       color: clientColor
         ? new THREE.Color(
-          clientColor.r / 255,
-          clientColor.g / 255,
-          clientColor.b / 255
-        )
+            clientColor.r / 255,
+            clientColor.g / 255,
+            clientColor.b / 255
+          )
         : 'black'
     });
 
@@ -1952,7 +1952,7 @@ export class MainView extends React.Component<IProps, IStates> {
                 itemId={key}
                 model={this._model.annotationModel}
                 open={false}
-              // open={annotation.open} // TODO: "open" missing from the IAnnotation interface?
+                // open={annotation.open} // TODO: "open" missing from the IAnnotation interface?
               />
             </div>
           );

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1182,10 +1182,10 @@ export class MainView extends React.Component<IProps, IStates> {
     const material = new THREE.MeshBasicMaterial({
       color: clientColor
         ? new THREE.Color(
-            clientColor.r / 255,
-            clientColor.g / 255,
-            clientColor.b / 255
-          )
+          clientColor.r / 255,
+          clientColor.g / 255,
+          clientColor.b / 255
+        )
         : 'black'
     });
 
@@ -1521,10 +1521,15 @@ export class MainView extends React.Component<IProps, IStates> {
   ): void {
     if (change.key === 'axes') {
       this._sceneAxe?.removeFromParent();
-      const axe = change.newValue as AxeHelper | undefined;
-
+      const axe = change.newValue as AxeHelper;
       if (change.type !== 'remove' && axe && axe.visible) {
-        this._sceneAxe = new THREE.AxesHelper(axe.size);
+        const axesHelper = new THREE.AxesHelper(
+          this._refLength ? this._refLength * 5 : 20
+        );
+        const material = axesHelper.material as THREE.LineBasicMaterial;
+        material.depthTest = false;
+        axesHelper.renderOrder = 1;
+        this._sceneAxe = axesHelper;
         this._scene.add(this._sceneAxe);
       }
     }
@@ -1947,7 +1952,7 @@ export class MainView extends React.Component<IProps, IStates> {
                 itemId={key}
                 model={this._model.annotationModel}
                 open={false}
-                // open={annotation.open} // TODO: "open" missing from the IAnnotation interface?
+              // open={annotation.open} // TODO: "open" missing from the IAnnotation interface?
               />
             </div>
           );

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -11,7 +11,6 @@ export type ValueOf<T> = T[keyof T];
  * Axe's dimensions
  */
 export type AxeHelper = {
-  size: number;
   visible: boolean;
 };
 

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -114,7 +114,7 @@ export class JupyterCadPanel extends SplitPanel {
   }) {
     this._view = new ObservableMap<JSONValue>({});
     const cameraSettings: CameraSettings = { type: 'Perspective' };
-    const axes: AxeHelper = { visible: false, size: 20 };
+    const axes: AxeHelper = { visible: false};
     this._view.set('cameraSettings', cameraSettings);
     const explodedView: ExplodedView = { enabled: false, factor: 0 };
     this._view.set('explodedView', explodedView);

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -114,7 +114,7 @@ export class JupyterCadPanel extends SplitPanel {
   }) {
     this._view = new ObservableMap<JSONValue>({});
     const cameraSettings: CameraSettings = { type: 'Perspective' };
-    const axes: AxeHelper = { visible: false};
+    const axes: AxeHelper = { visible: false };
     this._view.set('cameraSettings', cameraSettings);
     const explodedView: ExplodedView = { enabled: false, factor: 0 };
     this._view.set('explodedView', explodedView);

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -114,9 +114,11 @@ export class JupyterCadPanel extends SplitPanel {
   }) {
     this._view = new ObservableMap<JSONValue>({});
     const cameraSettings: CameraSettings = { type: 'Perspective' };
+    const axes: AxeHelper = { visible: false, size: 20 };
     this._view.set('cameraSettings', cameraSettings);
     const explodedView: ExplodedView = { enabled: false, factor: 0 };
     this._view.set('explodedView', explodedView);
+    this._view.set('axes', axes);
     this._mainViewModel = new MainViewModel({
       jcadModel: options.model,
       workerRegistry: options.workerRegistry,
@@ -162,12 +164,12 @@ export class JupyterCadPanel extends SplitPanel {
     return this._mainViewModel;
   }
 
-  get axes(): AxeHelper | undefined {
-    return this._view.get('axes') as AxeHelper | undefined;
+  get axes(): AxeHelper {
+    return this._view.get('axes') as AxeHelper;
   }
 
-  set axes(value: AxeHelper | undefined) {
-    this._view.set('axes', value || null);
+  set axes(value: AxeHelper) {
+    this._view.set('axes', value);
   }
 
   get explodedView(): ExplodedView {


### PR DESCRIPTION
Replace the FormDialog by a toggle button for the axes helper.
Set the material depthTest property to false in order to always render the axis on top of the shapes.

Should fix https://github.com/jupytercad/JupyterCAD/issues/718