### PR TITLE
Follow up of PR 726. Fix the axes helper toggle button broken behavior

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -962,6 +962,7 @@ export function addCommands(
           visible: true
         };
       }
+      commands.notifyCommandChanged(CommandIDs.updateAxes);
     }
   });
 


### PR DESCRIPTION
Fix the broken behavior for the axes helper toggle button with adding `notifyCommandChanged` in the execute method of `updateAxes` command.