### PR TITLE
Update the switch mode label for the transform controls

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1985,7 +1985,9 @@ export class MainView extends React.Component<IProps, IStates> {
             {isTransformOrClipEnabled && (
               <div>
                 <div style={{ marginBottom: '2px' }}>
-                  Press R to switch mode
+                  {this.state.transformMode === 'rotate'
+                    ? 'Press R to switch to translation mode'
+                    : 'Press R to switch to rotation mode'}
                 </div>
                 {this.state.transformMode === 'rotate' && (
                   <div>


### PR DESCRIPTION
Update the switch mode label for the transform controls. 
If the user is in translation mode, the label proposes to switch to the rotation mode and vice versa.