### PR TITLE
Apply the transform control on the parent when clicking on an edge

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1308,28 +1308,46 @@ export class MainView extends React.Component<IProps, IStates> {
   private _updateTransformControls(selection: string[]) {
     if (selection.length === 1 && !this._explodedView.enabled) {
       const selectedMeshName = selection[0];
-      const matchingChild = this._meshGroup?.children.find(child =>
+
+      if (selectedMeshName.startsWith('edge')) {
+        const selectedMesh = this._meshGroup?.getObjectByName(
+          selectedMeshName
+        ) as BasicMesh;
+
+        if (selectedMesh.parent?.name) {
+          const parentName = selectedMesh.parent.name;
+
+          // Not using getObjectByName, we want the full group
+          // TODO Improve this detection of the full group. startsWith looks brittle
+          const parent = this._meshGroup?.children.find(child =>
+            child.name.startsWith(parentName)
+          );
+
+          if (parent) {
+            this._transformControls.attach(parent as BasicMesh);
+
+            this._transformControls.visible = this.state.transform;
+            this._transformControls.enabled = this.state.transform;
+          }
+        }
+        return;
+      }
+
+      // Not using getObjectByName, we want the full group
+      // TODO Improve this detection of the full group. startsWith looks brittle
+      const selectedMesh = this._meshGroup?.children.find(child =>
         child.name.startsWith(selectedMeshName)
       );
 
-      if (matchingChild && selectedMeshName.startsWith('edge')) {
-        const parent = matchingChild.parent;
-        if (parent) {
-          this._transformControls.attach(parent as BasicMesh);
-        }
-      } else {
-        this._transformControls.attach(matchingChild as BasicMesh);
+      if (selectedMesh) {
+        this._transformControls.attach(selectedMesh as BasicMesh);
+
+        this._transformControls.visible = this.state.transform;
+        this._transformControls.enabled = this.state.transform;
+
+        return;
       }
-      this._transformControls.visible = this.state.transform;
-      this._transformControls.enabled = this.state.transform;
-      return;
     }
-
-    // Detach TransformControls from the previous selection
-    this._transformControls.detach();
-
-    this._transformControls.visible = false;
-    this._transformControls.enabled = false;
   }
 
   private _onSharedMetadataChanged = (

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1312,14 +1312,17 @@ export class MainView extends React.Component<IProps, IStates> {
         child.name.startsWith(selectedMeshName)
       );
 
-      if (matchingChild) {
+      if (matchingChild && selectedMeshName.startsWith('edge')) {
+        const parent = matchingChild.parent;
+        if (parent) {
+          this._transformControls.attach(parent as BasicMesh);
+        }
+      } else {
         this._transformControls.attach(matchingChild as BasicMesh);
-
-        this._transformControls.visible = this.state.transform;
-        this._transformControls.enabled = this.state.transform;
-
-        return;
       }
+      this._transformControls.visible = this.state.transform;
+      this._transformControls.enabled = this.state.transform;
+      return;
     }
 
     // Detach TransformControls from the previous selection

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1348,6 +1348,12 @@ export class MainView extends React.Component<IProps, IStates> {
         return;
       }
     }
+
+    // Detach TransformControls from the previous selection
+    this._transformControls.detach();
+
+    this._transformControls.visible = false;
+    this._transformControls.enabled = false;
   }
 
   private _onSharedMetadataChanged = (


### PR DESCRIPTION
Apply the transform control on the parent when clicking on an edge
Alternative solution to disabling edge selection as suggested from https://github.com/jupytercad/JupyterCAD/issues/714, fix #714 

