### PR TITLE
Properly handle lumino events

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -115,6 +115,7 @@ export class MainView extends React.Component<IProps, IStates> {
     );
     this._mainViewModel.renderSignal.connect(this._requestRender, this);
     this._mainViewModel.workerBusy.connect(this._workerBusyHandler, this);
+    this._mainViewModel.afterShowSignal.connect(this._handleWindowResize, this);
 
     this._raycaster.params.Line2 = { threshold: 50 };
 
@@ -134,7 +135,6 @@ export class MainView extends React.Component<IProps, IStates> {
   }
 
   componentDidMount(): void {
-    window.addEventListener('resize', this._handleWindowResize);
     this.generateScene();
     this.addContextMenu();
     this._mainViewModel.initWorker();
@@ -1730,9 +1730,6 @@ export class MainView extends React.Component<IProps, IStates> {
 
     this._transformControls.camera = this._camera;
     this._clipPlaneTransformControls.camera = this._camera;
-
-    const resizeEvent = new Event('resize');
-    window.dispatchEvent(resizeEvent);
   }
 
   private _updateSplit(enabled: boolean) {

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -1730,6 +1730,8 @@ export class MainView extends React.Component<IProps, IStates> {
 
     this._transformControls.camera = this._camera;
     this._clipPlaneTransformControls.camera = this._camera;
+
+    this.resizeCanvasToDisplaySize();
   }
 
   private _updateSplit(enabled: boolean) {

--- a/packages/base/src/3dview/mainviewmodel.ts
+++ b/packages/base/src/3dview/mainviewmodel.ts
@@ -52,6 +52,14 @@ export class MainViewModel implements IDisposable {
     return this._renderSignal;
   }
 
+  get afterShowSignal(): ISignal<this, null> {
+    return this._afterShowSignal;
+  }
+
+  emitAfterShow() {
+    this._afterShowSignal.emit(null);
+  }
+
   get workerBusy(): ISignal<this, boolean> {
     return this._workerBusy;
   }
@@ -322,6 +330,7 @@ export class MainViewModel implements IDisposable {
       postResult?: IDict<IPostOperatorInput>;
     }
   >(this);
+  private _afterShowSignal = new Signal<this, null>(this);
   private _workerBusy = new Signal<this, boolean>(this);
   private _isDisposed = false;
 }

--- a/packages/base/src/3dview/mainviewwidget.tsx
+++ b/packages/base/src/3dview/mainviewwidget.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { MainView } from './mainview';
 import { MainViewModel } from './mainviewmodel';
+import { Message } from '@lumino/messaging';
 
 export class JupyterCadMainViewPanel extends ReactWidget {
   /**
@@ -14,6 +15,18 @@ export class JupyterCadMainViewPanel extends ReactWidget {
     super();
     this._mainViewModel = options.mainViewModel;
     this.addClass('jp-jupytercad-panel');
+  }
+
+  processMessage(msg: Message): void {
+    super.processMessage(msg);
+
+    switch (msg.type) {
+      case 'resize':
+      case 'after-show':
+      case 'after-attach':
+        this._mainViewModel.emitAfterShow();
+        break;
+    }
   }
 
   render(): JSX.Element {

--- a/python/jupytercad_core/src/plugin.ts
+++ b/python/jupytercad_core/src/plugin.ts
@@ -39,16 +39,6 @@ export const trackerPlugin: JupyterFrontEndPlugin<IJupyterCadTracker> = {
     const tracker = new WidgetTracker<JupyterCadWidget>({
       namespace: NAME_SPACE
     });
-    tracker.currentChanged.connect(() => {
-      const currentWidget = tracker.currentWidget;
-
-      if (currentWidget) {
-        requestAnimationFrame(() => {
-          const resizeEvent = new Event('resize');
-          window.dispatchEvent(resizeEvent);
-        });
-      }
-    });
     console.log('jupytercad:core:tracker is activated!');
     return tracker;
   }


### PR DESCRIPTION
Fix https://github.com/jupytercad/JupyterCAD/issues/690

Also fixes issues with the scene disappearing when switching tabs between notebook and cad editor

- handle lumino resize event
- handle lumino after-show event (when switching tabs)
- handle lumino after-attach event (when the widget is added)