### PR TITLE
Add 'New JupyterCAD file' option to context menu (jupytercad#634)

### DIFF
--- a/python/jupytercad_core/src/jcadplugin/plugins.ts
+++ b/python/jupytercad_core/src/jcadplugin/plugins.ts
@@ -126,7 +126,7 @@ const activate = (
   });
 
   app.commands.addCommand(CommandIDs.createNew, {
-    label: args => 'CAD File',
+    label: args => (args['label'] as string) ?? 'CAD file',
     caption: 'Create a new JCAD Editor',
     icon: logoIcon,
     execute: async args => {
@@ -180,6 +180,14 @@ const activate = (
       });
     }
   }
+
+  // Inject “New JupyterCAD file” into the File Browser context menu
+  app.contextMenu.addItem({
+    command: CommandIDs.createNew,
+    selector: '.jp-DirListing',
+    rank: 55,
+    args: { label: 'New JupyterCAD file' }
+  });
 };
 
 const jcadPlugin: JupyterFrontEndPlugin<void> = {


### PR DESCRIPTION
Modified the jupytercad_core plugins.ts to add a new "New JupyterCAD File" option when opening up the file browser context menu. I gave this option a rank of 55 so it sits nicely after the "New File" and "New Notebook" options but before the "New Folder" option.

Fixes #634