### PR TITLE
Add multi-edge chamfer and fillet creation (jupytercad#646)

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -459,7 +459,6 @@ const OPERATORS = {
       return {
         Name: newName('Chamfer', model),
         Base: baseName,
-        // now supply an array
         Edge: selectedEdges?.edgeIndices || [],
         Dist: 0.2,
         Color: baseModel?.parameters?.Color || DEFAULT_MESH_COLOR,

--- a/packages/occ-worker/src/occapi/chamfer.ts
+++ b/packages/occ-worker/src/occapi/chamfer.ts
@@ -34,10 +34,12 @@ export function _Chamfer(
       mapOfShape
     );
 
-    const edge = oc.TopoDS.Edge_1(mapOfShape.FindKey(Edge + 1));
-
     const chamferBuilder = new oc.BRepFilletAPI_MakeChamfer(base.occShape);
-    chamferBuilder.Add_2(Dist, edge);
+    const edgeList = Array.isArray(Edge) ? Edge : [Edge];
+    for (const edgeIdx of edgeList) {
+      const e = oc.TopoDS.Edge_1(mapOfShape.FindKey(edgeIdx + 1));
+      chamferBuilder.Add_2(Dist, e);
+    }
 
     chamferBuilder.Build(new oc.Message_ProgressRange_1());
 

--- a/packages/occ-worker/src/occapi/fillet.ts
+++ b/packages/occ-worker/src/occapi/fillet.ts
@@ -34,13 +34,15 @@ export function _Fillet(
       mapOfShape
     );
 
-    const edge = oc.TopoDS.Edge_1(mapOfShape.FindKey(Edge + 1));
-
     const filletBuilder = new oc.BRepFilletAPI_MakeFillet(
       base.occShape,
       oc.ChFi3d_FilletShape
     );
-    filletBuilder.Add_2(Radius, edge);
+    const edgeList = Array.isArray(Edge) ? Edge : [Edge];
+    for (const edgeIdx of edgeList) {
+      const e = oc.TopoDS.Edge_1(mapOfShape.FindKey(edgeIdx + 1));
+      filletBuilder.Add_2(Radius, e);
+    }
 
     filletBuilder.Build(new oc.Message_ProgressRange_1());
 

--- a/packages/schema/src/schema/chamfer.json
+++ b/packages/schema/src/schema/chamfer.json
@@ -11,9 +11,21 @@
       "fcType": "App::PropertyLink"
     },
     "Edge": {
-      "type": "number",
-      "minimum": 0,
-      "description": "The edge index"
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "description": "The edge index"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "minimum": 0
+          },
+          "description": "List of edge indices"
+        }
+      ]
     },
     "Dist": {
       "type": "number",

--- a/packages/schema/src/schema/fillet.json
+++ b/packages/schema/src/schema/fillet.json
@@ -11,9 +11,21 @@
       "fcType": "App::PropertyLink"
     },
     "Edge": {
-      "type": "number",
-      "minimum": 0,
-      "description": "The edge index"
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "description": "The edge index"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "minimum": 0
+          },
+          "description": "List of edge indices"
+        }
+      ]
     },
     "Radius": {
       "type": "number",


### PR DESCRIPTION
Fixes #646 
As @martinRenou suggested, I modified the schemas for chamfer and fillet to make them support either multiple edges (an array of numbers) or a single edge represented by a number (for backwards compatibility with the old jcad files present in /examples for example).
Then in commands.ts, modified the getSelectedEdge() function and the operators for chamfer and fillet accordingly (by making them work for multiple edges). The new getSelectedEdges() is a bit too verbose because I had to deal with a lot of eslint issues, but feel free to change it if you'd like.
And did the same for chamfer.ts and fillet.ts.

I tested on Jupyter lab and it should be working fine. However, like I said in another issue, I can't be sure this works on the standalone version since there seem to be a lot of issues (for me at least) with it.
Also worth noting that this only works on a single object and not if you select multiple objects from different objects (even if they are identical).