### PR TITLE
Right click drag

### DIFF
--- a/packages/base/src/3dview/helpers.ts
+++ b/packages/base/src/3dview/helpers.ts
@@ -68,6 +68,7 @@ export interface IPickedResult {
 export interface IMouseDrag {
   start: THREE.Vector2;
   end: THREE.Vector2;
+  button?: number;
 }
 
 export interface IMeshGroupMetadata {

--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -311,7 +311,6 @@ export class MainView extends React.Component<IProps, IStates> {
       this._renderer.domElement.addEventListener('contextmenu', e => {
         e.preventDefault();
         e.stopPropagation();
-        this._contextMenu.open(e);
       });
 
       document.addEventListener('keydown', e => {
@@ -332,6 +331,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
       this._renderer.domElement.addEventListener('mousedown', e => {
         this._mouseDrag.start.set(e.clientX, e.clientY);
+        this._mouseDrag.button = e.button;
       });
 
       this._renderer.domElement.addEventListener('mouseup', e => {
@@ -339,7 +339,11 @@ export class MainView extends React.Component<IProps, IStates> {
         const distance = this._mouseDrag.end.distanceTo(this._mouseDrag.start);
 
         if (distance <= CLICK_THRESHOLD) {
-          this._onClick(e);
+          if (this._mouseDrag.button === 0) {
+            this._onClick(e);
+          } else if (this._mouseDrag.button === 2) {
+            this._contextMenu.open(e);
+          }
         }
       });
 

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -459,6 +459,7 @@ const OPERATORS = {
       return {
         Name: newName('Chamfer', model),
         Base: baseName,
+        // now supply an array
         Edge: selectedEdges?.edgeIndices || [],
         Dist: 0.2,
         Color: baseModel?.parameters?.Color || DEFAULT_MESH_COLOR,

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -459,7 +459,6 @@ const OPERATORS = {
       return {
         Name: newName('Chamfer', model),
         Base: baseName,
-        // now supply an array
         Edge: selectedEdges?.edgeIndices || [],
         Dist: 0.2,
         Color: baseModel?.parameters?.Color || DEFAULT_MESH_COLOR,


### PR DESCRIPTION
Fixes #739 
This took me a while but after a few different ideas, I was able to find a really simple solution that leverages the already created event listeners for the left mouse click and the left click drag functionality. I had to extend the IMouseDrag interface by adding an optional attribute for the button that tells us whether the click was a left mouse click or a right mouse click.
The idea here was to move the command that opens the context menu out of the "contextmenu" handler and into the "mouseup" listener so that it only opens when we have clicked and released the right mouse button without dragging it more than CLICK_THRESHOLD (which is 5 pixels).

