### PR TITLE
Add "Export to .FCStd" command

### DIFF
--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -90,6 +90,7 @@ export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
 
   readonly editable: boolean;
   readonly toJcadEndpoint?: string;
+  readonly toFcstdEndpoint?: string;
 
   objectExists(name: string): boolean;
   getObjectByName(name: string): IJCadObject | undefined;

--- a/python/jupytercad_lab/src/index.ts
+++ b/python/jupytercad_lab/src/index.ts
@@ -129,6 +129,9 @@ function populateMenus(mainMenu: IMainMenu, isEnabled: () => boolean): void {
   mainMenu.fileMenu.addItem({
     command: CommandIDs.exportJcad
   });
+  mainMenu.fileMenu.addItem({
+    command: CommandIDs.exportFcstd
+  });
   // Add undo/redo hooks to the edit menu.
   mainMenu.editMenu.undoers.redo.add({
     id: CommandIDs.redo,


### PR DESCRIPTION
This PR needs the latest PR of JupyterCAD-FreeCaAD to be merged to work, i.e the PR "Add option to export jcad files to FCStd and vice versa"
It adds to the "File" tab the command "Export to .FCStd"