### PR TITLE
Add STL/BREP export feature.

### DIFF
--- a/packages/base/src/3dview/mainviewmodel.ts
+++ b/packages/base/src/3dview/mainviewmodel.ts
@@ -124,6 +124,8 @@ export class MainViewModel implements IDisposable {
             rawPostResult[key] = val;
           } else if (format === JCadWorkerSupportedFormat.GLTF) {
             threejsPostResult[key] = val;
+          } else if (format === JCadWorkerSupportedFormat.STL) {
+            rawPostResult[key] = val;
           }
         });
 

--- a/packages/base/src/panelview/objecttree.tsx
+++ b/packages/base/src/panelview/objecttree.tsx
@@ -440,12 +440,14 @@ class ObjectTreeReact extends React.Component<IProps, IStates> {
             if (jcadObj) {
               visible = jcadObj.visible;
             }
+            const isParentNode = opts.node.parentId === null;
 
             return (
               <div
                 className={`jpcad-control-panel-tree ${
                   opts.selected ? 'selected' : ''
-                }`}
+                } ${isParentNode ? 'jpcad-object-tree-item' : ''}`}
+                data-object-name={isParentNode ? (opts.node.id as string) : null}
                 onClick={() => this.handleNodeClick(opts.node.id as string)}
               >
                 <div

--- a/packages/occ-worker/src/occapi/postOperator.ts
+++ b/packages/occ-worker/src/occapi/postOperator.ts
@@ -2,6 +2,7 @@ import { IJCadContent, IPostOperator } from '@jupytercad/schema';
 
 import { IOperatorArg } from '../types';
 import { _writeBrep } from './brepIO';
+import { _writeStlFile } from './stlIO';
 import { getShapesFactory } from './common';
 
 export function _PostOperator(
@@ -21,6 +22,37 @@ export function _PostOperator(
     );
     if (base?.occShape) {
       const postShape = _writeBrep(base.occShape);
+      return { postShape };
+    }
+  }
+  return { postShape: '' };
+}
+
+export function _PostOperatorForSTL(
+  arg: IPostOperator,
+  content: IJCadContent
+): { postShape: string } {
+  const baseObject = content.objects.filter(obj => obj.name === arg.Object);
+  if (baseObject.length === 0) {
+    return { postShape: '' };
+  }
+  const shapesFactory = getShapesFactory();
+  const baseShape = baseObject[0].shape;
+  if (baseShape && shapesFactory[baseShape]) {
+    const base = shapesFactory[baseShape]?.(
+      baseObject[0].parameters as IOperatorArg,
+      content
+    );
+    if (base?.occShape) {
+      // Extract deflection settings from the Post operator parameters
+      const linearDeflection = arg.LinearDeflection;
+      const angularDeflection = arg.AngularDeflection;
+
+      const postShape = _writeStlFile(
+        base.occShape,
+        linearDeflection,
+        angularDeflection
+      );
       return { postShape };
     }
   }

--- a/packages/occ-worker/src/occapi/postOperator.ts
+++ b/packages/occ-worker/src/occapi/postOperator.ts
@@ -21,38 +21,16 @@ export function _PostOperator(
       content
     );
     if (base?.occShape) {
-      const postShape = _writeBrep(base.occShape);
-      return { postShape };
-    }
-  }
-  return { postShape: '' };
-}
-
-export function _PostOperatorForSTL(
-  arg: IPostOperator,
-  content: IJCadContent
-): { postShape: string } {
-  const baseObject = content.objects.filter(obj => obj.name === arg.Object);
-  if (baseObject.length === 0) {
-    return { postShape: '' };
-  }
-  const shapesFactory = getShapesFactory();
-  const baseShape = baseObject[0].shape;
-  if (baseShape && shapesFactory[baseShape]) {
-    const base = shapesFactory[baseShape]?.(
-      baseObject[0].parameters as IOperatorArg,
-      content
-    );
-    if (base?.occShape) {
-      // Extract deflection settings from the Post operator parameters
-      const linearDeflection = arg.LinearDeflection;
-      const angularDeflection = arg.AngularDeflection;
-
-      const postShape = _writeStlFile(
-        base.occShape,
-        linearDeflection,
-        angularDeflection
-      );
+      let postShape = '';
+      if (arg.Type === 'BREP') {
+        postShape = _writeBrep(base.occShape);
+      } else if (arg.Type === 'STL') {
+        postShape = _writeStlFile(
+          base.occShape,
+          arg.LinearDeflection,
+          arg.AngularDeflection
+        );
+      }
       return { postShape };
     }
   }

--- a/packages/occ-worker/src/occapi/stlIO.ts
+++ b/packages/occ-worker/src/occapi/stlIO.ts
@@ -25,8 +25,8 @@ export function _loadStlFile(content: string): OCC.TopoDS_Shape | undefined {
 
 export function _writeStlFile(
   shape: OCC.TopoDS_Shape,
-  linearDeflection = 0.01,
-  angularDeflection = 0.05
+  linearDeflection = 0.1,
+  angularDeflection = 0.5
 ): string {
   const oc = getOcc();
 

--- a/packages/occ-worker/src/occapi/stlIO.ts
+++ b/packages/occ-worker/src/occapi/stlIO.ts
@@ -30,17 +30,12 @@ export function _writeStlFile(
 ): string {
   const oc = getOcc();
 
-  console.log(
-    `🔧 Using STL settings - Linear: ${linearDeflection}, Angular: ${angularDeflection}`
-  );
-
-  // Set tessellation parameters on the shape before writing
   new oc.BRepMesh_IncrementalMesh_2(
     shape,
-    linearDeflection, // Linear deflection (smaller = more triangles)
-    false, // Relative mode
-    angularDeflection, // Angular deflection in radians
-    true // Parallel processing
+    linearDeflection,
+    false,
+    angularDeflection,
+    true
   );
 
   const writer = new oc.StlAPI_Writer();

--- a/packages/occ-worker/src/occapi/stlIO.ts
+++ b/packages/occ-worker/src/occapi/stlIO.ts
@@ -52,9 +52,7 @@ export function _writeStlFile(
       encoding: 'utf8'
     }) as string;
 
-    console.log(
-      `✅ Generated STL (Linear: ${linearDeflection}, Angular: ${angularDeflection}), length: ${stlContent.length}`
-    );
+    console.log(`Generated STL content, length: ${stlContent.length}`);
     return stlContent;
   } finally {
     if (oc.FS.analyzePath(fakeFileName).exists) {

--- a/packages/opencascade/build.yml
+++ b/packages/opencascade/build.yml
@@ -78,6 +78,7 @@ mainBuild:
     - symbol: Standard_Transient
     - symbol: StdPrs_ToolTriangulatedShape
     - symbol: STEPControl_Reader
+    - symbol: StlAPI_Writer
     - symbol: TColgp_Array1OfDir
     - symbol: TColgp_Array1OfPnt
     - symbol: TColStd_Array1OfInteger

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -324,7 +324,8 @@ export type IMessageHandler =
 
 export enum JCadWorkerSupportedFormat {
   BREP = 'BREP',
-  GLTF = 'GLTF'
+  GLTF = 'GLTF',
+  STL = 'STL'
 }
 export interface IJCadWorker {
   ready: Promise<void>;

--- a/packages/schema/src/schema/postOperator.json
+++ b/packages/schema/src/schema/postOperator.json
@@ -8,6 +8,12 @@
     "Object": {
       "type": "string",
       "description": "The name of input object"
+    },
+    "Type": {
+      "type": "string",
+      "default": "BREP",
+      "enum": ["BREP", "STL"],
+      "description": "The filetype for export (Brep/Stl)"
     }
   }
 }

--- a/python/jupytercad_core/src/stlplugin/commands.ts
+++ b/python/jupytercad_core/src/stlplugin/commands.ts
@@ -19,8 +19,14 @@ const formSchema = {
   properties: {
     Object: {
       type: 'string',
-      description: 'The object to export to STL',
+      description: 'The object to export',
       enum: []
+    },
+    Type: {
+      type: 'string',
+      default: 'STL',
+      enum: ['BREP', 'STL'],
+      description: 'The filetype for export (Brep/Stl)'
     },
     LinearDeflection: {
       type: 'number',
@@ -37,7 +43,7 @@ const formSchema = {
       default: 0.05
     }
   },
-  required: ['Object'],
+  required: ['Object', 'Type'],
   additionalProperties: false
 };
 
@@ -139,6 +145,7 @@ namespace Private {
           ? `${selectedObjectName}_STL_Export`
           : 'STL_Export',
         Object: selectedObjectName,
+        Type: 'STL',
         LinearDeflection: 0.1,
         AngularDeflection: 0.5
       };

--- a/python/jupytercad_core/src/stlplugin/commands.ts
+++ b/python/jupytercad_core/src/stlplugin/commands.ts
@@ -34,14 +34,14 @@ const formSchema = {
       description: 'Linear deflection (smaller = more triangles)',
       minimum: 0.0001,
       maximum: 1.0,
-      default: 0.01
+      default: 0.1
     },
     AngularDeflection: {
       type: 'number',
       description: 'Angular deflection in radians',
       minimum: 0.01,
       maximum: 1.0,
-      default: 0.05
+      default: 0.5
     }
   },
   required: ['Object', 'Type'],
@@ -70,7 +70,7 @@ export function addCommands(
 }
 
 namespace Private {
-  const stlOperator = {
+  const exportOperator = {
     title: 'Export to STL/BREP',
     syncData: (model: IJupyterCadModel) => {
       return (props: IDict) => {
@@ -186,10 +186,10 @@ namespace Private {
 
       const dialog = new FormDialog({
         model: current.model,
-        title: stlOperator.title,
+        title: exportOperator.title,
         sourceData,
         schema: formJsonSchema,
-        syncData: stlOperator.syncData(current.model),
+        syncData: exportOperator.syncData(current.model),
         cancelButton: true
       });
       await dialog.launch();

--- a/python/jupytercad_core/src/stlplugin/commands.ts
+++ b/python/jupytercad_core/src/stlplugin/commands.ts
@@ -1,0 +1,126 @@
+import { FormDialog } from '@jupytercad/base';
+import {
+  IDict,
+  //   IJCadObject,
+  //   IJupyterCadModel,
+  IJupyterCadTracker
+} from '@jupytercad/schema';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { showErrorMessage } from '@jupyterlab/apputils';
+import { ITranslator } from '@jupyterlab/translation';
+
+export namespace CommandIDs {
+  export const exportSTL = 'jupytercad:stl:export';
+}
+
+// The form schema is now defined directly here
+const formSchema = {
+  type: 'object',
+  properties: {
+    Object: {
+      type: 'string',
+      description: 'The object to export to STL',
+      enum: []
+    },
+    LinearDeflection: {
+      type: 'number',
+      description: 'Linear deflection (smaller = more triangles)',
+      minimum: 0.0001,
+      maximum: 1.0,
+      default: 0.01
+    },
+    AngularDeflection: {
+      type: 'number',
+      description: 'Angular deflection in radians',
+      minimum: 0.01,
+      maximum: 1.0,
+      default: 0.05
+    }
+  },
+  required: ['Object'],
+  additionalProperties: false
+};
+
+export function addCommands(
+  app: JupyterFrontEnd,
+  tracker: IJupyterCadTracker,
+  translator: ITranslator
+) {
+  const trans = translator.load('jupyterlab');
+  const { commands } = app;
+  commands.addCommand(CommandIDs.exportSTL, {
+    label: trans.__('Export to STL...'),
+    isEnabled: () => Boolean(tracker.currentWidget),
+    execute: Private.executeExportSTL(app, tracker)
+  });
+}
+
+namespace Private {
+  export function executeExportSTL(
+    app: JupyterFrontEnd,
+    tracker: IJupyterCadTracker
+  ) {
+    return async (args: any) => {
+      const current = tracker.currentWidget;
+
+      if (!current) {
+        return;
+      }
+      const model = current.model;
+      if (!model) {
+        return;
+      }
+
+      const formJsonSchema = JSON.parse(JSON.stringify(formSchema));
+      const objects = model.getAllObject();
+      const objectNames = objects.map(obj => obj.name);
+
+      if (objectNames.length === 0) {
+        showErrorMessage(
+          'No Objects',
+          'There are no objects in the document to export.'
+        );
+        return;
+      }
+
+      formJsonSchema.properties.Object.enum = objectNames;
+
+      // Find the right-clicked object name from the DOM
+      const node = app.contextMenuHitTest(node =>
+        node.classList.contains('jpcad-object-tree-item')
+      );
+      const clickedObjectName = node?.dataset.objectName;
+
+      const selected = model.localState?.selected?.value || {};
+      const selectedObjectNames = Object.keys(selected);
+      const selectedObjectName =
+        clickedObjectName ||
+        (selectedObjectNames.length > 0
+          ? selectedObjectNames[0]
+          : objectNames[0]);
+
+      const sourceData = {
+        Object: selectedObjectName,
+        LinearDeflection: 0.01,
+        AngularDeflection: 0.05
+      };
+
+      const dialog = new FormDialog({
+        model,
+        title: 'Export to STL',
+        sourceData,
+        schema: formJsonSchema,
+        syncData: (props: IDict) => {
+          // TODO: This is where the new logic will go.
+          // 1. Call viewModel.exportObject(props.Object, 'STL', { ...options })
+          // 2. Receive STL content
+          // 3. Trigger download
+          console.log('Export properties:', props);
+          alert('Exporting is not implemented yet!');
+        },
+        cancelButton: true
+      });
+      await dialog.launch();
+    };
+  }
+}

--- a/python/jupytercad_core/src/stlplugin/plugins.ts
+++ b/python/jupytercad_core/src/stlplugin/plugins.ts
@@ -6,7 +6,6 @@ import {
   IJCadWorkerRegistry,
   IJCadWorkerRegistryToken,
   IJupyterCadDocTracker,
-  // IJupyterCadTracker,
   IJupyterCadWidget,
   IJCadExternalCommandRegistry,
   IJCadExternalCommandRegistryToken
@@ -31,7 +30,7 @@ const SETTINGS_ID = '@jupytercad/jupytercad-core:jupytercad-settings';
 
 const activate = async (
   app: JupyterFrontEnd,
-  tracker: WidgetTracker<IJupyterCadWidget>, // CORRECT: Using the concrete class
+  tracker: WidgetTracker<IJupyterCadWidget>,
   themeManager: IThemeManager,
   workerRegistry: IJCadWorkerRegistry,
   externalCommandRegistry: IJCadExternalCommandRegistry,
@@ -100,17 +99,16 @@ const activate = async (
   widgetFactory.widgetCreated.connect((sender, widget) => {
     widget.title.icon = stlIcon;
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget); // This works because the type is WidgetTracker
+      tracker.save(widget);
     });
     themeManager.themeChanged.connect((_, changes) =>
       widget.model.themeChanged.emit(changes)
     );
-    tracker.add(widget); // This also works
+    tracker.add(widget);
     app.shell.activateById('jupytercad::leftControlPanel');
     app.shell.activateById('jupytercad::rightControlPanel');
   });
 
-  // Add the command to the context menu for the object tree
   app.contextMenu.addItem({
     command: CommandIDs.exportSTL,
     selector: '.jpcad-object-tree-item',

--- a/python/jupytercad_core/src/stlplugin/plugins.ts
+++ b/python/jupytercad_core/src/stlplugin/plugins.ts
@@ -24,6 +24,7 @@ import { JupyterCadStlDoc } from './model';
 import { stlIcon } from '@jupytercad/base';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { addCommands, CommandIDs } from './commands';
+import { STLWorker } from './worker';
 
 const FACTORY = 'JupyterCAD STL Viewer';
 const SETTINGS_ID = '@jupytercad/jupytercad-core:jupytercad-settings';
@@ -51,6 +52,10 @@ const activate = async (
   } else {
     console.warn('No settingRegistry available; using default settings.');
   }
+
+  const WORKER_ID = 'jupytercad-stl:worker';
+  const worker = new STLWorker({ tracker });
+  workerRegistry.registerWorker(WORKER_ID, worker);
 
   addCommands(app, tracker, translator);
 

--- a/python/jupytercad_core/src/stlplugin/plugins.ts
+++ b/python/jupytercad_core/src/stlplugin/plugins.ts
@@ -23,7 +23,8 @@ import { JupyterCadStlDoc } from './model';
 import { stlIcon } from '@jupytercad/base';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { addCommands, CommandIDs } from './commands';
-import { STLWorker } from './worker';
+import { ExportWorker } from './worker';
+import { JCadWorkerSupportedFormat } from '@jupytercad/schema';
 
 const FACTORY = 'JupyterCAD STL Viewer';
 const SETTINGS_ID = '@jupytercad/jupytercad-core:jupytercad-settings';
@@ -52,9 +53,17 @@ const activate = async (
     console.warn('No settingRegistry available; using default settings.');
   }
 
-  const WORKER_ID = 'jupytercad-stl:worker';
-  const worker = new STLWorker({ tracker });
-  workerRegistry.registerWorker(WORKER_ID, worker);
+  const stlWorker = new ExportWorker({
+    tracker,
+    shapeFormat: JCadWorkerSupportedFormat.STL
+  });
+  workerRegistry.registerWorker('jupytercad-stl:worker', stlWorker);
+
+  const brepWorker = new ExportWorker({
+    tracker,
+    shapeFormat: JCadWorkerSupportedFormat.BREP
+  });
+  workerRegistry.registerWorker('jupytercad-brep:worker', brepWorker);
 
   addCommands(app, tracker, translator);
 

--- a/python/jupytercad_core/src/stlplugin/plugins.ts
+++ b/python/jupytercad_core/src/stlplugin/plugins.ts
@@ -16,6 +16,7 @@ import {
 } from '@jupyterlab/application';
 import { IThemeManager, WidgetTracker } from '@jupyterlab/apputils';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import { Menu } from '@lumino/widgets';
 
 import { JupyterCadStlModelFactory } from './modelfactory';
 import { JupyterCadDocumentWidgetFactory } from '../factory';
@@ -118,8 +119,15 @@ const activate = async (
     app.shell.activateById('jupytercad::rightControlPanel');
   });
 
+  // Create the export submenu
+  const exportMenu = new Menu({ commands: app.commands });
+  exportMenu.title.label = 'Export as';
+  exportMenu.addItem({ command: CommandIDs.exportAsSTL });
+  exportMenu.addItem({ command: CommandIDs.exportAsBREP });
+
   app.contextMenu.addItem({
-    command: CommandIDs.exportSTL,
+    type: 'submenu',
+    submenu: exportMenu,
     selector: '.jpcad-object-tree-item',
     rank: 10
   });

--- a/python/jupytercad_core/src/stlplugin/worker.ts
+++ b/python/jupytercad_core/src/stlplugin/worker.ts
@@ -41,7 +41,6 @@ export class STLWorker implements IJCadWorker {
     if (msg.payload && Object.keys(msg.payload).length > 0) {
       const jCadObject = msg.payload['jcObject'] as IJCadObject;
       const stlContent = msg.payload['postShape'];
-
       if (stlContent && typeof stlContent === 'string') {
         this._downloadSTL(jCadObject.name, stlContent);
       } else {
@@ -58,7 +57,6 @@ export class STLWorker implements IJCadWorker {
 
     const link = document.createElement('a');
     link.href = url;
-    // Use the original object's name for the download, not the temporary export object's name
     const originalObjectName = objectName.replace(/_STL_Export$/, '');
     link.download = `${originalObjectName
       .toLowerCase()

--- a/python/jupytercad_core/src/stlplugin/worker.ts
+++ b/python/jupytercad_core/src/stlplugin/worker.ts
@@ -1,0 +1,98 @@
+import {
+  IJCadObject,
+  IJCadWorker,
+  IJupyterCadTracker,
+  IWorkerMessageBase,
+  JCadWorkerSupportedFormat,
+  WorkerAction
+} from '@jupytercad/schema';
+import { PromiseDelegate } from '@lumino/coreutils';
+import { v4 as uuid } from 'uuid';
+
+export class STLWorker implements IJCadWorker {
+  constructor(options: STLWorker.IOptions) {
+    this._tracker = options.tracker;
+  }
+
+  shapeFormat = JCadWorkerSupportedFormat.STL;
+
+  get ready(): Promise<void> {
+    return this._ready.promise;
+  }
+
+  register(options: {
+    messageHandler: ((msg: any) => void) | ((msg: any) => Promise<void>);
+    thisArg?: any;
+  }): string {
+    const id = uuid();
+    // No-op
+    return id;
+  }
+
+  unregister(id: string): void {
+    // No-op
+  }
+
+  postMessage(msg: IWorkerMessageBase): void {
+    if (msg.action !== WorkerAction.POSTPROCESS) {
+      return;
+    }
+
+    if (msg.payload && Object.keys(msg.payload).length > 0) {
+      const jCadObject = msg.payload['jcObject'] as IJCadObject;
+      const stlContent = msg.payload['postShape'];
+
+      if (stlContent && typeof stlContent === 'string') {
+        this._downloadSTL(jCadObject.name, stlContent);
+      } else {
+        console.error('No STL content received for object:', jCadObject.name);
+      }
+    }
+  }
+
+  private _downloadSTL(objectName: string, stlContent: string): void {
+    const blob = new Blob([stlContent], {
+      type: 'application/octet-stream'
+    });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    // Use the original object's name for the download, not the temporary export object's name
+    const originalObjectName = objectName.replace(/_STL_Export$/, '');
+    link.download = `${originalObjectName
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '_')}.stl`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    this._cleanupExportObject(objectName);
+  }
+
+  private _cleanupExportObject(exportObjectName: string): void {
+    const currentWidget = this._tracker.currentWidget;
+    if (!currentWidget) {
+      return;
+    }
+
+    const model = currentWidget.model;
+    const sharedModel = model.sharedModel;
+
+    if (sharedModel && sharedModel.objectExists(exportObjectName)) {
+      sharedModel.transact(() => {
+        sharedModel.removeObjectByName(exportObjectName);
+      });
+    }
+  }
+
+  private _ready = new PromiseDelegate<void>();
+  private _tracker: IJupyterCadTracker;
+}
+
+export namespace STLWorker {
+  export interface IOptions {
+    tracker: IJupyterCadTracker;
+  }
+}


### PR DESCRIPTION
This PR adds the option to export jcad shapes as STL/BREP files.
![image](https://github.com/user-attachments/assets/f0f15644-ee95-4aaa-9535-595c7fb41077)
The command can be accessed by right-clicking on a shape in the objects tree view and selecting the output file (either STL or BREP for now).
For STL files you can modify the linear and angular deflections to control the mesh resolution.

The main changes that have been made to the code are the following:
-Added support for STL as a JCadSupportedFormat in interfaces.ts, mainviewmodel.ts and actions.ts.
-Modified the schema for postOperator.json so that it now has the file type for the export.
-Modified the OCC build to compile the StlAPI_Writer function.
-Created _writeStlFile function in stlIO.ts that uses the StlAPI_Writer function to generate the STL content.
-Added a case that uses this function in postOperator.ts.
-Created worker.ts under stlplugin to receive the STL content response from the OCC worker and trigger the download.
-Created commands.ts and modified objecttree.tsx to add the context menu and the dialog form.
-Modified plugins.ts to register the workers.