### PR TITLE
Restore the users item visibility

### DIFF
--- a/python/jupytercad_app/RELEASE.md
+++ b/python/jupytercad_app/RELEASE.md
@@ -82,7 +82,6 @@ Here is a summary of the steps to cut a new release:
 - If the repo generates PyPI release(s), create a scoped PyPI [token](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github). We recommend using a scoped token for security reasons.
 
 - You can store the token as `PYPI_TOKEN` in your fork's `Secrets`.
-
   - Advanced usage: if you are releasing multiple repos, you can create a secret named `PYPI_TOKEN_MAP` instead of `PYPI_TOKEN` that is formatted as follows:
 
     ```text

--- a/python/jupytercad_core/style/base.css
+++ b/python/jupytercad_core/style/base.css
@@ -3,3 +3,7 @@
 
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html
 */
+
+jp-toolbar.jpcad-toolbar-widget .jp-MenuBar-anonymousIcon {
+  position: unset !important;
+}


### PR DESCRIPTION
Remove the `position: absolute` of the `.jp-MenuBar-anonymousIcon`, which led to a parent DOM with no size, no taken into account by the toolbar spacer.

Fix #763.