### PR TITLE
Fix pressing delete key in form from deleting entire object.

### DIFF
--- a/packages/base/src/panelview/formbuilder.tsx
+++ b/packages/base/src/panelview/formbuilder.tsx
@@ -152,7 +152,9 @@ export class ObjectPropertiesForm extends React.Component<IProps, IStates> {
           className="jpcad-property-panel"
           data-path={this.props.filePath ?? ''}
           // Prevent any key press from propagating to other elements
-          onKeyDown={(e: React.KeyboardEvent) => {e.stopPropagation();}}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            e.stopPropagation();
+          }}
         >
           <div
             className="jpcad-property-outer jp-scrollbar-tiny"


### PR DESCRIPTION
If I wanted to remove **bad_text** from the *Object Properties > Radius 1* text field:

(NOTE: I haven't written much typescript before, so very much welcome any edits/feedback - I did wonder if I needed to include the `|| e.key === 'Backspace'` bit, also I'm happy to try writing a UI test for this if helpful?)

### Before

https://github.com/user-attachments/assets/18859d80-e026-4d61-adc0-7cfabab945ec

### After

https://github.com/user-attachments/assets/49cf8725-b249-444c-b491-88ffc0d5affa

Thanks!