### PR TITLE
Remove `POINT` from sketcher widget

### DIFF
--- a/packages/base/src/sketcher/sketcherwidget.tsx
+++ b/packages/base/src/sketcher/sketcherwidget.tsx
@@ -121,9 +121,6 @@ export class SketcherReactWidget extends React.Component<IProps, IState> {
         }
         break;
       }
-      case 'POINT': {
-        break;
-      }
       default:
         break;
     }
@@ -197,10 +194,6 @@ export class SketcherReactWidget extends React.Component<IProps, IState> {
 
           model.startEdit('CIRCLE', { centerId, radius: 0 });
         }
-        break;
-      }
-      case 'POINT': {
-        model.addPoint(worldPos);
         break;
       }
       default:


### PR DESCRIPTION
Following on comments in https://github.com/jupytercad/JupyterCAD/pull/807 I thought it may be helpful to remove the "POINT" tab from the sketcher widget (see the video in https://github.com/jupytercad/JupyterCAD/pull/810#issuecomment-3508893992, of course no worries if not).

Thanks!