### PR TITLE
Measures support

### DIFF
--- a/packages/base/src/3dview/mainview.tsx
+++ b/packages/base/src/3dview/mainview.tsx
@@ -168,45 +168,45 @@ export class MainView extends React.Component<IProps, IStates> {
     document.addEventListener('keydown', this._keyDownHandler);
   }
 
-    componentDidUpdate(oldProps: IProps, oldState: IStates): void {
-      // Resize the canvas to fit the display area
-      this.resizeCanvasToDisplaySize();
+  componentDidUpdate(oldProps: IProps, oldState: IStates): void {
+    // Resize the canvas to fit the display area
+    this.resizeCanvasToDisplaySize();
 
-      // Update transform controls rotation snap if the value has changed
-      if (oldState.rotationSnapValue !== this.state.rotationSnapValue) {
-        this._transformControls.rotationSnap = THREE.MathUtils.degToRad(
-          this.state.rotationSnapValue
-        );
-      }
+    // Update transform controls rotation snap if the value has changed
+    if (oldState.rotationSnapValue !== this.state.rotationSnapValue) {
+      this._transformControls.rotationSnap = THREE.MathUtils.degToRad(
+        this.state.rotationSnapValue
+      );
+    }
 
-      // Update transform controls translation snap if the value has changed
-      if (oldState.translationSnapValue !== this.state.translationSnapValue) {
-        this._transformControls.translationSnap = this.state.translationSnapValue;
-      }
+    // Update transform controls translation snap if the value has changed
+    if (oldState.translationSnapValue !== this.state.translationSnapValue) {
+      this._transformControls.translationSnap = this.state.translationSnapValue;
+    }
 
-      // Handle measurement display based on the selection box
-      if (oldState.selectionBox !== this.state.selectionBox) {
-        // If there is a new selection box, create and display measurements
-        if (this.state.selectionBox) {
-          // Clear any existing measurement visuals
-          if (this._measurementGroup) {
-            this._measurementGroup.clear();
-            this._scene.remove(this._measurementGroup);
-          }
-          // Create a new measurement object for the selection box
-          const measurement = new Measurement({ box: this.state.selectionBox });
-          this._measurementGroup = measurement.group;
-          this._scene.add(this._measurementGroup);
-        } else {
-          // If the selection box is removed, clear the measurement visuals
-          if (this._measurementGroup) {
-            this._measurementGroup.clear();
-            this._scene.remove(this._measurementGroup);
-            this._measurementGroup = null;
-          }
+    // Handle measurement display based on the selection box
+    if (oldState.selectionBox !== this.state.selectionBox) {
+      // If there is a new selection box, create and display measurements
+      if (this.state.selectionBox) {
+        // Clear any existing measurement visuals
+        if (this._measurementGroup) {
+          this._measurementGroup.clear();
+          this._scene.remove(this._measurementGroup);
+        }
+        // Create a new measurement object for the selection box
+        const measurement = new Measurement({ box: this.state.selectionBox });
+        this._measurementGroup = measurement.group;
+        this._scene.add(this._measurementGroup);
+      } else {
+        // If the selection box is removed, clear the measurement visuals
+        if (this._measurementGroup) {
+          this._measurementGroup.clear();
+          this._scene.remove(this._measurementGroup);
+          this._measurementGroup = null;
         }
       }
     }
+  }
 
   componentWillUnmount(): void {
     window.cancelAnimationFrame(this._requestID);
@@ -697,7 +697,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
     this._renderer.render(this._scene, this._camera);
 
-    this._labelRenderer.render(this._scene, this._camera);  // Render the 2D labels on top of the 3D scene
+    this._labelRenderer.render(this._scene, this._camera); // Render the 2D labels on top of the 3D scene
     this._viewHelper.render(this._renderer);
     this.updateCameraRotation();
   };
@@ -715,7 +715,7 @@ export class MainView extends React.Component<IProps, IStates> {
         this._divRef.current.clientWidth,
         this._divRef.current.clientHeight
       );
-      
+
       if (this._camera instanceof THREE.PerspectiveCamera) {
         this._camera.aspect =
           this._divRef.current.clientWidth / this._divRef.current.clientHeight;

--- a/packages/base/src/3dview/measurement.tsx
+++ b/packages/base/src/3dview/measurement.tsx
@@ -135,7 +135,9 @@ export class Measurement extends React.Component<IMeasurementProps> {
     const label = new CSS2DObject(labelDiv);
 
     // Position the label at the midpoint of the line
-    const midPoint = new THREE.Vector3().addVectors(start, end).multiplyScalar(0.5);
+    const midPoint = new THREE.Vector3()
+      .addVectors(start, end)
+      .multiplyScalar(0.5);
     label.position.copy(midPoint);
 
     this._group.add(label);

--- a/ui-tests/tests/measurement.spec.ts
+++ b/ui-tests/tests/measurement.spec.ts
@@ -14,9 +14,7 @@ test.describe('Measurement test', () => {
     );
   });
 
-  test('Should display measurement on object selection', async ({
-    page
-  }) => {
+  test('Should display measurement on object selection', async ({ page }) => {
     test.setTimeout(120000);
     await page.goto();
 
@@ -33,9 +31,15 @@ test.describe('Measurement test', () => {
       .click();
 
     // Check if the measurement labels are displayed
-    const xLabel = page.locator('.measurement-label', { hasText: /X: \d+\.\d{2}/ });
-    const yLabel = page.locator('.measurement-label', { hasText: /Y: \d+\.\d{2}/ });
-    const zLabel = page.locator('.measurement-label', { hasText: /Z: \d+\.\d{2}/ });
+    const xLabel = page.locator('.measurement-label', {
+      hasText: /X: \d+\.\d{2}/
+    });
+    const yLabel = page.locator('.measurement-label', {
+      hasText: /Y: \d+\.\d{2}/
+    });
+    const zLabel = page.locator('.measurement-label', {
+      hasText: /Z: \d+\.\d{2}/
+    });
 
     await expect(xLabel).toBeVisible();
     await expect(yLabel).toBeVisible();


### PR DESCRIPTION
Fixes https://github.com/jupytercad/JupyterCAD/issues/124

- On selection of an edge or object, XYZ sizes are shown on those axes:

https://github.com/user-attachments/assets/25d6e7a0-a76d-4177-9036-3235dc1fd015

- Can select multiple objects, which results in the total dimensions being shown:

https://github.com/user-attachments/assets/b7c5c8db-e343-4bfa-8667-08fe0b56e454

(This highlights the dimensions are actually represented with a dashed line - we can see this by removing a selected object:

https://github.com/user-attachments/assets/9ff334c9-5889-4520-b446-37adc9809975

I have noticed that when transforming a shape the dimension labels don't move with it, but deselecting and re-selecting it correctly updates the location (but I could try and get the labels to move with it if you think this is possible and would prefer it):

https://github.com/user-attachments/assets/8000cda6-3f19-4004-915b-c99a17e58f40


---

Very much welcome any thoughts: I did wonder if would we like to have a button to toggle measurements, instead of always showing them whenever an object is selected (I think this might also fix the broken snapshot UI tests)? Thanks!
