### PR TITLE
Update releaser for trusted publishers

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 


### PR DESCRIPTION
I setted up the trusted publisher for PyPi and NPM packages, those tokens are of no use anymore