### PR TITLE
Fix ambiguity with file format

### DIFF
--- a/lite/jupyter_lite_config.json
+++ b/lite/jupyter_lite_config.json
@@ -4,20 +4,20 @@
       "jcad": {
         "name": "jcad",
         "extensions": [".jcad", ".JCAD"],
-        "mimeTypes": ["text/plain"],
-        "fileFormat": "text"
+        "mimeTypes": ["application/json"],
+        "fileFormat": "json"
       },
       "step": {
         "name": "step",
         "extensions": [".step", ".STEP"],
-        "mimeTypes": ["text/plain"],
-        "fileFormat": "text"
+        "mimeTypes": ["application/json"],
+        "fileFormat": "json"
       },
       "stl": {
         "name": "stl",
         "extensions": [".stl", ".STL"],
-        "mimeTypes": ["text/plain"],
-        "fileFormat": "text"
+        "mimeTypes": ["application/json"],
+        "fileFormat": "json"
       }
     }
   }

--- a/python/jupytercad_core/src/jcadplugin/modelfactory.ts
+++ b/python/jupytercad_core/src/jcadplugin/modelfactory.ts
@@ -45,7 +45,7 @@ export class JupyterCadJcadModelFactory implements DocumentRegistry.IModelFactor
    * @returns the file format
    */
   get fileFormat(): Contents.FileFormat {
-    return 'text';
+    return 'json';
   }
 
   /**

--- a/python/jupytercad_core/src/jcadplugin/plugins.ts
+++ b/python/jupytercad_core/src/jcadplugin/plugins.ts
@@ -111,9 +111,9 @@ const activate = async (
   app.docRegistry.addFileType({
     name: CONTENT_TYPE,
     displayName: 'JCAD',
-    mimeTypes: ['text/json'],
+    mimeTypes: ['application/json'],
     extensions: ['.jcad', '.JCAD'],
-    fileFormat: 'text',
+    fileFormat: 'json',
     icon: logoIcon
   });
 

--- a/python/jupytercad_core/src/jcadplugin/plugins.ts
+++ b/python/jupytercad_core/src/jcadplugin/plugins.ts
@@ -176,7 +176,13 @@ const activate = async (
         ...model,
         format: 'text',
         size: undefined,
-        content: `{\n\t"schemaVersion": "${SCHEMA_VERSION}",\n\t"objects": [],\n\t"options": {},\n\t"metadata": {},\n\t"outputs": {}}`
+        content: {
+          schemaVersion: SCHEMA_VERSION,
+          objects: [],
+          options: {},
+          metadata: {},
+          outputs: {}
+        }
       });
 
       // Open the newly created file with the 'Editor'

--- a/python/jupytercad_core/src/stepplugin/modelfactory.ts
+++ b/python/jupytercad_core/src/stepplugin/modelfactory.ts
@@ -64,7 +64,7 @@ export class JupyterCadStepModelFactory implements DocumentRegistry.IModelFactor
    * @returns the file format
    */
   get fileFormat(): Contents.FileFormat {
-    return 'text';
+    return 'json';
   }
 
   /**

--- a/python/jupytercad_core/src/stepplugin/plugins.ts
+++ b/python/jupytercad_core/src/stepplugin/plugins.ts
@@ -65,9 +65,9 @@ const activate = async (
   app.docRegistry.addFileType({
     name: 'step',
     displayName: 'STEP',
-    mimeTypes: ['text/plain'],
+    mimeTypes: ['application/json'],
     extensions: ['.step', '.STEP'],
-    fileFormat: 'text',
+    fileFormat: 'json',
     icon: stpIcon
   });
 

--- a/python/jupytercad_core/src/stlplugin/modelfactory.ts
+++ b/python/jupytercad_core/src/stlplugin/modelfactory.ts
@@ -61,7 +61,7 @@ export class JupyterCadStlModelFactory implements DocumentRegistry.IModelFactory
    * @returns the file format
    */
   get fileFormat(): Contents.FileFormat {
-    return 'text';
+    return 'json';
   }
 
   /**

--- a/python/jupytercad_core/src/stlplugin/plugins.ts
+++ b/python/jupytercad_core/src/stlplugin/plugins.ts
@@ -83,9 +83,9 @@ const activate = async (
   app.docRegistry.addFileType({
     name: 'stl',
     displayName: 'STL',
-    mimeTypes: ['text/plain'],
+    mimeTypes: ['application/json'],
     extensions: ['.stl', '.STL'],
-    fileFormat: 'text',
+    fileFormat: 'json',
     icon: stlIcon
   });
 

--- a/python/jupytercad_lab/src/notebookrenderer.ts
+++ b/python/jupytercad_lab/src/notebookrenderer.ts
@@ -202,8 +202,8 @@ export const notebookRenderePlugin: JupyterFrontEndPlugin<void> = {
             await app.serviceManager.contents.get(localPath);
           } catch (e) {
             await app.serviceManager.contents.save(localPath, {
-              content: btoa('{}'),
-              format: 'base64'
+              content: {},
+              format: 'json'
             });
           }
         } else {


### PR DESCRIPTION
`getSource` returns a JSON object for collaboration, but we specify our fileformat as being "text"