### PR TITLE
Fix: sharedModel.source should be a string, not JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-prettier": "5.0.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "lerna": "^7.0.0",
+    "license-webpack-plugin": "^2.3.14",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
     "rimraf": "^3.0.2",
@@ -77,6 +78,7 @@
     "stylelint-prettier": "^4.0.0",
     "typescript": "^5",
     "webpack": ">=5.76.3 <5.107.0",
-    "webpack-cli": "^5"
+    "webpack-cli": "^5",
+    "webpack-merge": "^5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "stylelint-csstree-validator": "^3.0.0",
     "stylelint-prettier": "^4.0.0",
     "typescript": "^5",
-    "webpack": "^5.76.3"
+    "webpack": ">=5.76.3 <5.107.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "stylelint-csstree-validator": "^3.0.0",
     "stylelint-prettier": "^4.0.0",
     "typescript": "^5",
-    "webpack": ">=5.76.3 <5.107.0"
+    "webpack": ">=5.76.3 <5.107.0",
+    "webpack-cli": "^7.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "stylelint-prettier": "^4.0.0",
     "typescript": "^5",
     "webpack": ">=5.76.3 <5.107.0",
-    "webpack-cli": "^7.0.3"
+    "webpack-cli": "^5"
   }
 }

--- a/packages/occ-worker/package.json
+++ b/packages/occ-worker/package.json
@@ -51,7 +51,7 @@
     "ts-loader": "^9.2.6",
     "tsc-watch": "^6.0.0",
     "typescript": "^5",
-    "webpack": "^5.76.3"
+    "webpack": ">=5.76.3 <5.107.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -66,13 +66,13 @@ export class JupyterCadDoc
     return this._optionsChanged;
   }
 
-  getSource(): JSONObject {
+  getSource(): string {
     const objects = this._objects.toJSON();
     const options = this._options.toJSON();
     const metadata = this._metadata.toJSON();
     const outputs = this._outputs.toJSON();
 
-    return { objects, options, metadata, outputs };
+    return JSON.stringify({ objects, options, metadata, outputs }, null, '  ');
   }
 
   setSource(source: JSONObject | string): void {

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -111,7 +111,7 @@ export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   setOutput(key: string, value: IPostResult): void;
   removeOutput(key: string): void;
 
-  getSource(): JSONObject;
+  getSource(): string;
   setSource(value: JSONObject | string): void;
 
   getMetadata(key: string): string | undefined;

--- a/python/jupytercad_app/package.json
+++ b/python/jupytercad_app/package.json
@@ -116,7 +116,7 @@
     "rimraf": "^3.0.2",
     "tsc-watch": "^6.0.0",
     "typescript": "^5",
-    "webpack": "^5.76.3"
+    "webpack": ">=5.76.3 <5.107.0"
   },
   "sideEffects": [
     "style/*.css",

--- a/python/jupytercad_core/package.json
+++ b/python/jupytercad_core/package.json
@@ -82,7 +82,7 @@
     "rimraf": "^3.0.2",
     "style-loader": "^3.3.1",
     "typescript": "^5",
-    "webpack": "^5.76.3",
+    "webpack": ">=5.76.3 <5.107.0",
     "yjs": "^13.5.0"
   },
   "sideEffects": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9144,7 +9144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
+"json-parse-even-better-errors@npm:^2.3.0":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
@@ -10168,7 +10168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27":
+"mime-types@npm:^2.1.12":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -14423,7 +14423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:>=5.76.3 <5.107.0":
+"webpack@npm:>=5.76.3 <5.107.0, webpack@npm:^5.76.1, webpack@npm:^5.77.0":
   version: 5.106.2
   resolution: "webpack@npm:5.106.2"
   dependencies:
@@ -14457,44 +14457,6 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: fd44725871b6777b62cdcbb32492b48740bbd575811c2c45e1c9c9413d0cbf4de7aa9931b3ccfd072d155f811de3584951264bfa30164a5e2f5db66cbf52b260
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.76.1, webpack@npm:^5.77.0":
-  version: 5.105.4
-  resolution: "webpack@npm:5.105.4"
-  dependencies:
-    "@types/eslint-scope": ^3.7.7
-    "@types/estree": ^1.0.8
-    "@types/json-schema": ^7.0.15
-    "@webassemblyjs/ast": ^1.14.1
-    "@webassemblyjs/wasm-edit": ^1.14.1
-    "@webassemblyjs/wasm-parser": ^1.14.1
-    acorn: ^8.16.0
-    acorn-import-phases: ^1.0.3
-    browserslist: ^4.28.1
-    chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.20.0
-    es-module-lexer: ^2.0.0
-    eslint-scope: 5.1.1
-    events: ^3.2.0
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.2.11
-    json-parse-even-better-errors: ^2.3.1
-    loader-runner: ^4.3.1
-    mime-types: ^2.1.27
-    neo-async: ^2.6.2
-    schema-utils: ^4.3.3
-    tapable: ^2.3.0
-    terser-webpack-plugin: ^5.3.17
-    watchpack: ^2.5.1
-    webpack-sources: ^3.3.4
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: b1a109016630b2817463981d28aa760f2a9a4cbb0098875ea40abbe694f5b93c708ab3cbca577865faf4046d9946cca7f660fa5a872440605008e19a5874182b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,6 +1092,7 @@ __metadata:
     eslint-plugin-prettier: 5.0.1
     eslint-plugin-react-hooks: ^4.6.2
     lerna: ^7.0.0
+    license-webpack-plugin: ^2.3.14
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
     rimraf: ^3.0.2
@@ -1103,6 +1104,7 @@ __metadata:
     typescript: ^5
     webpack: ">=5.76.3 <5.107.0"
     webpack-cli: ^5
+    webpack-merge: ^5.8
   languageName: unknown
   linkType: soft
 
@@ -14343,7 +14345,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
+"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8, webpack-merge@npm:^5.8.0":
   version: 5.10.0
   resolution: "webpack-merge@npm:5.10.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,7 +1007,7 @@ __metadata:
     rimraf: ^3.0.2
     tsc-watch: ^6.0.0
     typescript: ^5
-    webpack: ^5.76.3
+    webpack: ">=5.76.3 <5.107.0"
     yjs: ^13.5.40
     yjs-widgets: ^0.4
   languageName: unknown
@@ -1043,7 +1043,7 @@ __metadata:
     style-loader: ^3.3.1
     typescript: ^5
     util: ^0.12.5
-    webpack: ^5.76.3
+    webpack: ">=5.76.3 <5.107.0"
     yjs: ^13.5.0
   languageName: unknown
   linkType: soft
@@ -1101,7 +1101,7 @@ __metadata:
     stylelint-csstree-validator: ^3.0.0
     stylelint-prettier: ^4.0.0
     typescript: ^5
-    webpack: ^5.76.3
+    webpack: ">=5.76.3 <5.107.0"
   languageName: unknown
   linkType: soft
 
@@ -1122,7 +1122,7 @@ __metadata:
     tsc-watch: ^6.0.0
     typescript: ^5
     uuid: ^8.3.2
-    webpack: ^5.76.3
+    webpack: ">=5.76.3 <5.107.0"
   languageName: unknown
   linkType: soft
 
@@ -10146,6 +10146,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: e99aaf2f23f5bd607deb08c83faba5dd25cf2fec90a7cc5b92d8260867ee08dab65312e1a589e60093dc7796d41e5fae013268418482f1db4c7d52d0a0960ac9
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12, mime-types@npm:^2.1.27":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
@@ -14363,7 +14370,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.76.1, webpack@npm:^5.76.3, webpack@npm:^5.77.0":
+"webpack@npm:>=5.76.3 <5.107.0":
+  version: 5.106.2
+  resolution: "webpack@npm:5.106.2"
+  dependencies:
+    "@types/eslint-scope": ^3.7.7
+    "@types/estree": ^1.0.8
+    "@types/json-schema": ^7.0.15
+    "@webassemblyjs/ast": ^1.14.1
+    "@webassemblyjs/wasm-edit": ^1.14.1
+    "@webassemblyjs/wasm-parser": ^1.14.1
+    acorn: ^8.16.0
+    acorn-import-phases: ^1.0.3
+    browserslist: ^4.28.1
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.20.0
+    es-module-lexer: ^2.0.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.11
+    loader-runner: ^4.3.1
+    mime-db: ^1.54.0
+    neo-async: ^2.6.2
+    schema-utils: ^4.3.3
+    tapable: ^2.3.0
+    terser-webpack-plugin: ^5.3.17
+    watchpack: ^2.5.1
+    webpack-sources: ^3.3.4
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: fd44725871b6777b62cdcbb32492b48740bbd575811c2c45e1c9c9413d0cbf4de7aa9931b3ccfd072d155f811de3584951264bfa30164a5e2f5db66cbf52b260
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.76.1, webpack@npm:^5.77.0":
   version: 5.105.4
   resolution: "webpack@npm:5.105.4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,13 +522,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discoveryjs/json-ext@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@discoveryjs/json-ext@npm:1.1.0"
-  checksum: f16d3732629095cbe37d42d504a80c44261dd5ad703ec5963729dab0786b2b8a2b86f81cf9d1dd593ad914d50146ecd281eeac60bfe9cf246257f84c57b72204
-  languageName: node
-  linkType: hard
-
 "@emotion/is-prop-valid@npm:^1.1.0, @emotion/is-prop-valid@npm:^1.2.0":
   version: 1.4.0
   resolution: "@emotion/is-prop-valid@npm:1.4.0"
@@ -1109,7 +1102,7 @@ __metadata:
     stylelint-prettier: ^4.0.0
     typescript: ^5
     webpack: ">=5.76.3 <5.107.0"
-    webpack-cli: ^7.0.3
+    webpack-cli: ^5
   languageName: unknown
   linkType: soft
 
@@ -5403,13 +5396,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^14.0.3":
-  version: 14.0.3
-  resolution: "commander@npm:14.0.3"
-  checksum: b8440159124aefbb02784a8996cd0481d8ce503d8d3cd413f4289d06db7e912c36b511277c2faba62f59152dd9ff79239d75e3b9400d9402851878994201d429
-  languageName: node
-  linkType: hard
-
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -6715,7 +6701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:^7.14.0, envinfo@npm:^7.7.3":
+"envinfo@npm:^7.7.3":
   version: 7.21.0
   resolution: "envinfo@npm:7.21.0"
   bin:
@@ -14325,7 +14311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:^5.0.1":
+"webpack-cli@npm:^5, webpack-cli@npm:^5.0.1":
   version: 5.1.4
   resolution: "webpack-cli@npm:5.1.4"
   dependencies:
@@ -14357,33 +14343,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "webpack-cli@npm:7.0.3"
-  dependencies:
-    "@discoveryjs/json-ext": ^1.1.0
-    commander: ^14.0.3
-    cross-spawn: ^7.0.6
-    envinfo: ^7.14.0
-    import-local: ^3.0.2
-    interpret: ^3.1.1
-    rechoir: ^0.8.0
-    webpack-merge: ^6.0.1
-  peerDependencies:
-    webpack: ^5.101.0
-    webpack-bundle-analyzer: ^4.0.0 || ^5.0.0
-    webpack-dev-server: ^5.0.0
-  peerDependenciesMeta:
-    webpack-bundle-analyzer:
-      optional: true
-    webpack-dev-server:
-      optional: true
-  bin:
-    webpack-cli: bin/cli.js
-  checksum: bf3f9ef77c305945a4033b7b08b52ac2fd3c0373aeb8e06abc158d4568e60ecc0f42ddf932fef42bbaf10835b1a34c61ef2a0920ab187822123b907d10b5bf5d
-  languageName: node
-  linkType: hard
-
 "webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
   version: 5.10.0
   resolution: "webpack-merge@npm:5.10.0"
@@ -14392,17 +14351,6 @@ __metadata:
     flat: ^5.0.2
     wildcard: ^2.0.0
   checksum: 1fe8bf5309add7298e1ac72fb3f2090e1dfa80c48c7e79fa48aa60b5961332c7d0d61efa8851acb805e6b91a4584537a347bc106e05e9aec87fa4f7088c62f2f
-  languageName: node
-  linkType: hard
-
-"webpack-merge@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "webpack-merge@npm:6.0.1"
-  dependencies:
-    clone-deep: ^4.0.1
-    flat: ^5.0.2
-    wildcard: ^2.0.1
-  checksum: e8a604c686b944605a1c57cc7b75e886ab902dc5ffdd15259a092c5c2dd5f58868fe39f995ea4bad4f189e38843b061c4ae1eb22822d7169813f4adab571dc3d
   languageName: node
   linkType: hard
 
@@ -14628,7 +14576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wildcard@npm:^2.0.0, wildcard@npm:^2.0.1":
+"wildcard@npm:^2.0.0":
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: e0c60a12a219e4b12065d1199802d81c27b841ed6ad6d9d28240980c73ceec6f856771d575af367cbec2982d9ae7838759168b551776577f155044f5a5ba843c

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,6 +522,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discoveryjs/json-ext@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@discoveryjs/json-ext@npm:1.1.0"
+  checksum: f16d3732629095cbe37d42d504a80c44261dd5ad703ec5963729dab0786b2b8a2b86f81cf9d1dd593ad914d50146ecd281eeac60bfe9cf246257f84c57b72204
+  languageName: node
+  linkType: hard
+
 "@emotion/is-prop-valid@npm:^1.1.0, @emotion/is-prop-valid@npm:^1.2.0":
   version: 1.4.0
   resolution: "@emotion/is-prop-valid@npm:1.4.0"
@@ -1102,6 +1109,7 @@ __metadata:
     stylelint-prettier: ^4.0.0
     typescript: ^5
     webpack: ">=5.76.3 <5.107.0"
+    webpack-cli: ^7.0.3
   languageName: unknown
   linkType: soft
 
@@ -5395,6 +5403,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: b8440159124aefbb02784a8996cd0481d8ce503d8d3cd413f4289d06db7e912c36b511277c2faba62f59152dd9ff79239d75e3b9400d9402851878994201d429
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -6700,7 +6715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:^7.7.3":
+"envinfo@npm:^7.14.0, envinfo@npm:^7.7.3":
   version: 7.21.0
   resolution: "envinfo@npm:7.21.0"
   bin:
@@ -14342,6 +14357,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-cli@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "webpack-cli@npm:7.0.3"
+  dependencies:
+    "@discoveryjs/json-ext": ^1.1.0
+    commander: ^14.0.3
+    cross-spawn: ^7.0.6
+    envinfo: ^7.14.0
+    import-local: ^3.0.2
+    interpret: ^3.1.1
+    rechoir: ^0.8.0
+    webpack-merge: ^6.0.1
+  peerDependencies:
+    webpack: ^5.101.0
+    webpack-bundle-analyzer: ^4.0.0 || ^5.0.0
+    webpack-dev-server: ^5.0.0
+  peerDependenciesMeta:
+    webpack-bundle-analyzer:
+      optional: true
+    webpack-dev-server:
+      optional: true
+  bin:
+    webpack-cli: bin/cli.js
+  checksum: bf3f9ef77c305945a4033b7b08b52ac2fd3c0373aeb8e06abc158d4568e60ecc0f42ddf932fef42bbaf10835b1a34c61ef2a0920ab187822123b907d10b5bf5d
+  languageName: node
+  linkType: hard
+
 "webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
   version: 5.10.0
   resolution: "webpack-merge@npm:5.10.0"
@@ -14350,6 +14392,17 @@ __metadata:
     flat: ^5.0.2
     wildcard: ^2.0.0
   checksum: 1fe8bf5309add7298e1ac72fb3f2090e1dfa80c48c7e79fa48aa60b5961332c7d0d61efa8851acb805e6b91a4584537a347bc106e05e9aec87fa4f7088c62f2f
+  languageName: node
+  linkType: hard
+
+"webpack-merge@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "webpack-merge@npm:6.0.1"
+  dependencies:
+    clone-deep: ^4.0.1
+    flat: ^5.0.2
+    wildcard: ^2.0.1
+  checksum: e8a604c686b944605a1c57cc7b75e886ab902dc5ffdd15259a092c5c2dd5f58868fe39f995ea4bad4f189e38843b061c4ae1eb22822d7169813f4adab571dc3d
   languageName: node
   linkType: hard
 
@@ -14613,7 +14666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wildcard@npm:^2.0.0":
+"wildcard@npm:^2.0.0, wildcard@npm:^2.0.1":
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: e0c60a12a219e4b12065d1199802d81c27b841ed6ad6d9d28240980c73ceec6f856771d575af367cbec2982d9ae7838759168b551776577f155044f5a5ba843c


### PR DESCRIPTION
Closes #868 

Even if our file format is indeed JSON, the jupyter-server contents manager only allow text or base64. So we must keep the text format.

The only issue is that getSource in the front-end was wrongly returning a JSON structure instead of string. Leading to some issues in jupyter-collaboration.